### PR TITLE
Fix TEI format for PURLs

### DIFF
--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -65,7 +65,7 @@ urn:tei:<type>:<domain>:<data>
 Syntax:
 
 ```text
-urn:tei:uuid:<domain or host>:<purl>
+urn:tei:purl:<domain or host>:<purl>
 ````
 
 #### SWID


### PR DESCRIPTION
I believe that this was a copy-paste error and is probably supposed to state "purl" instead of "uuid".