### PR TITLE
fix: GH workflows failing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea/
-out
+out/*

--- a/spec/generators/python.yaml
+++ b/spec/generators/python.yaml
@@ -4,5 +4,5 @@ generatorName: python
 additionalProperties:
   library: urllib3
   licenseInfo: "Apache-2.0"
-  packageName: "tea-api-client"
+  packageName: "tea_api_client"
   projectName: "Transparency Exchange API (TEA)"

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -76,7 +76,6 @@
                 
                 },
                 "tags": [
-                    "Consumer",
                     "TEA Index"
                 ]
             }
@@ -106,7 +105,6 @@
                     }
                 },
                 "tags": [
-                    "Consumer",
                     "TEA Leaf"
                 ]
             }
@@ -136,7 +134,6 @@
                     }
                 },
                 "tags": [
-                    "Consumer",
                     "TEA Collection"
                 ]
             }
@@ -533,8 +530,6 @@
     },
     "security": [],
     "tags": [
-        "Consumer",
-        "Producer",
         "TEA Collection",
         "TEA Index",
         "TEA Leaf"


### PR DESCRIPTION
This PR resolves initial failures of the GitHub Workflow to build and test generated API clients.

Fixes included:
- Ensuring initial output directory exists (`out`)
- Aligning Python generated package name (see `python.yaml`)
- Generated GO was invalid seemingly due to operations have more than one tag in the OpenAPI spec - moved to single tags