### PR TITLE
Discovery: Remove load balancing and failover support using DNS

### DIFF
--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -174,7 +174,8 @@ in DNS. The URI is composed of the name with the  "/.well-known/tea" prefix adde
 tea.example.com.   3600 IN HTTPS  1  tea01.prod.example.com.
 ```
 
-Results in `https://tea.example.com/.well-known/tea/<identifier>` while connecting to
+Results in the base URI (without the product identifier) 
+`https://tea.example.com/.well-known/tea/` while connecting to
 the host tea01.prod.example.com.
 
 ### Load balancing and fail over

--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -170,7 +170,7 @@ After selecting a host and resolving that to IP address, the TEA client
 connects to the host using HTTPS with the original name, not the one found
 in DNS. The URI is composed of the name with the `/.well-known/tea` prefix added.
 
-```text
+```zone_file
 tea.example.com.   3600 IN HTTPS  1  tea01.prod.example.com.
 ```
 

--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -192,7 +192,19 @@ If they are not reachable, tea03 will be used for failover.
 
 It is recommended to have a third party external repository as the last priority.
 
-### Finding the Index using DNS result
+## Connecting to the API
+
+When connecting to the ".well-known/tea" URI with the unique identifier
+a HTTP redirect is **required**.
+
+The server MUST redirect HTTP requests for that resource
+to the actual "context path" using one of the available mechanisms
+provided by HTTP (e.g., using a 301, 303, or 307 response).  Clients
+MUST handle HTTP redirects on the ".well-known" URI.  Servers MUST
+NOT locate the actual TEA service endpoint at the
+".well-known" URI as per Section 1.1 of [RFC5785].
+
+### Overview: Finding the Index using DNS result
 
 Append the product part of the TEI to the URI found
 

--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -20,7 +20,7 @@ of many digital devices or software applications. A "product" normally also has 
 entry in a large corporation's asset inventory system.
 
 A product identifier is embedded in a URN where the identifier is one of many existing
-identifiers or a random string - like an EAN bar code, UUID, product
+identifiers or a random string - like an EAN or UPC bar code, UUID, product
 number or PURL.
 
 The goal is for a user to add this URN to the transparency platform (sometimes with an
@@ -37,13 +37,13 @@ The TEI for a product can be communicated to the user in many ways.
 
 ## TEA Discovery - defining an extensible identifier
 
-TEA discovery is the process where a user with a product identifier can discover and downloadg
+TEA discovery is the process where a user with a product identifier can discover and download
 artifacts automatically, with or without authentication. A globally unique identifier is
 required for a given product. This identifier is called the Transparency Exchange Identifier (TEI).
 
 The TEI identifier is based on DNS, which assures a uniqueness per vendor (or open source project)
 and gives the vendor a name space to define product identifiers based on existing or new identifiers
-ike EAN bar code, PURLs or other existing schemes. A given product may have multiple identifiers
+like EAN/UPC bar code, PURLs or other existing schemes. A given product may have multiple identifiers
 as long as they all resolve into the same destination.
 
 ## The TEI URN: An extensible identifier
@@ -55,7 +55,7 @@ to global uniqueness without new registries.
 The TEI can be shown in the software itself, in shipping documentation, in web pages and app stores.
 TEI is unique for a product, not a version of a software. The TEI consist of three core parts
 
-A TEI belongs to a single product. A product can have multiple TEIs - like one with a EAN
+A TEI belongs to a single product. A product can have multiple TEIs - like one with a EAN/UPC
 barcode and one with the vendor's product number.
 
 ### TEI syntax
@@ -148,7 +148,7 @@ urn:tei:uuid:cyclonedx.org:d4d9f54a-abcf-11ee-ac79-1a52914d44b1
 
 ### TEI resolution using DNS
 
-The name part of the TEI is used in a DNS query to find one or multiple locations for
+The `domain-name` part of the TEI is used in a DNS query to find one or multiple locations for
 product transparency exchange information. DNS can deliver load balancing and
 failover functionality to make sure that the information is always reachable.
 
@@ -159,16 +159,16 @@ This is solved by using the ".well-known" name space as defined by the IETF.
 - Syntax: `urn:tei:uuid:<name based on domain>:<unique identifier>`
 
 The name in the DNS name part points to a set of DNS records.
-A TEI with name “tea.example.com" queries for `tea.example.com HTTPS records.
+A TEI with name `tea.example.com` queries for `tea.example.com` `HTTPS` records.
 These point to the hosts available for the Transparency Exchange API.
-Note that "tea.example.com" may not have A/AAAA records at all if it
-points to other servers, like "tea01.example.org" and "teahost.example.net".
+Note that `tea.example.com` may not have `A`/`AAAA` records at all if it
+points to other servers, like `tea01.example.org` and `teahost.example.net`.
 
-If there are no HTTPS records, try to resolve the name (using AAAA and A DNS records).
+If there are no HTTPS records, try to resolve the name (using `AAAA` and `A` DNS records).
 
 After selecting a host and resolving that to IP address, the TEA client
 connects to the host using HTTPS with the original name, not the one found
-in DNS. The URI is composed of the name with the  "/.well-known/tea" prefix added.
+in DNS. The URI is composed of the name with the `/.well-known/tea` prefix added.
 
 ```text
 tea.example.com.   3600 IN HTTPS  1  tea01.prod.example.com.
@@ -176,7 +176,7 @@ tea.example.com.   3600 IN HTTPS  1  tea01.prod.example.com.
 
 Results in the base URI (without the product identifier) 
 `https://tea.example.com/.well-known/tea/` while connecting to
-the host tea01.prod.example.com.
+the host `tea01.prod.example.com`.
 
 ### Load balancing and fail over
 
@@ -188,22 +188,22 @@ tea.example.com.   3600 IN HTTPS  10  tea02.prod.example.com.
 tea.example.com.   3600 IN HTTPS  20  tea03.prod.example.com.
 ```
 
-In this case servers tea01 and tea02 will get 50% of the load each.
-If they are not reachable, tea03 will be used for failover.
+In this case servers `tea01`and `tea02` will get 50% of the load each.
+If they are not reachable, `tea03` will be used for failover.
 
 It is recommended to have a third party external repository as the last priority.
 
 ## Connecting to the API
 
-When connecting to the ".well-known/tea" URI with the unique identifier
+When connecting to the `.well-known/tea` URI with the unique identifier
 a HTTP redirect is **required**.
 
 The server MUST redirect HTTP requests for that resource
 to the actual "context path" using one of the available mechanisms
 provided by HTTP (e.g., using a 301, 303, or 307 response).  Clients
-MUST handle HTTP redirects on the ".well-known" URI.  Servers MUST
+MUST handle HTTP redirects on the `.well-known` URI.  Servers MUST
 NOT locate the actual TEA service endpoint at the
-".well-known" URI as per Section 1.1 of [RFC5785].
+`.well-known` URI as per Section 1.1 of [RFC5785].
 
 ### Overview: Finding the Index using DNS result
 
@@ -211,15 +211,15 @@ Append the product part of the TEI to the URI found
 
 - TEI: `urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1`
 - DNS record: `products.example.com`
-- Server found in DNS HTTPS record: `teapot.prod.example.com`
+- Server found in DNS `HTTPS` record: `teapot.prod.example.com`
 - URL: `https://products.example.com/.well-known/tea/d4d9f54a-abcf-11ee-ac79-1a52914d44b1/`
 - HTTP 302 redirect to "https://teapot02.consumer.example.com/tea/v2/product-index/d4d9f54a-abcf-11ee-ac79-1a52914d44b1'
 
-The server at "teapot.prod.example.com" needs a TLS certificate including "products.example.com"
-in the subject alt name. "teapot02.consumer.example.com" needs a certificate with that
+The server at `teapot.prod.example.com` needs a TLS certificate that valid for `products.example.com` 
+ - e.g. with `products.example.com` in the subject alt name. `teapot02.consumer.example.com` needs a certificate with that
 host name.
 
-If no HTTPS records are found the resolution defaults to A and AAAA records.
+If no `HTTPS` records are found the resolution defaults to `A` and `AAAA` records.
 IP address is not valid in the domain name field.
 
 Append the URL prefix `/.well-known/tea/` of the TEI to the DNS name found

--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -12,26 +12,39 @@
 - [The TEA Version Index](#the-tea-version-index)
 - [References](#references)
 
-
 ## From product identifier to API endpoint
 
 TEA Discovery is the connection between a product identifier and the API endpoint.
+A "product" is something that the customer aquires or downloads. It can be a bundle
+of many digital devices or software applications. A "product" normally also has an
+entry in a large corporation's asset inventory system.
+
 A product identifier is embedded in a URN where the identifier is one of many existing
-identifiers or a random string - like an EAN bar code, product
+identifiers or a random string - like an EAN bar code, UUID, product
 number or PURL.
 
 The goal is for a user to add this URN to the transparency platform (sometimes with an
 associated authentication token) and have the platform access the required artifacts
 in a highly automated fashion.
 
+## Advertising the TEI
+
+The TEI for a product can be communicated to the user in many ways.
+
+- A QR code on a box
+- On the invoice or delivery note
+- For software with a GUI, in an "about" box
+
 ## TEA Discovery - defining an extensible identifier
 
-TEA discovery is the process where a user with a product identifier can discover and download
+TEA discovery is the process where a user with a product identifier can discover and downloadg
 artifacts automatically, with or without authentication. A globally unique identifier is
 required for a given product. This identifier is called the Transparency Exchange Identifier (TEI).
 
-The TEI identifier is based on DNS, which assures a uniqueness per vendor (or open source project) 
-and gives the vendor a name space to define product identifiers based on existing or new identifiers like EAN bar code, PURLs or other existing schemes. A given product may have multiple identifiers as long as they all resolve into the same destination.
+The TEI identifier is based on DNS, which assures a uniqueness per vendor (or open source project)
+and gives the vendor a name space to define product identifiers based on existing or new identifiers
+ike EAN bar code, PURLs or other existing schemes. A given product may have multiple identifiers
+as long as they all resolve into the same destination.
 
 ## The TEI URN: An extensible identifier
 
@@ -42,11 +55,6 @@ to global uniqueness without new registries.
 The TEI can be shown in the software itself, in shipping documentation, in web pages and app stores.
 TEI is unique for a product, not a version of a software. The TEI consist of three core parts
 
-- The **`type`** which defines the syntax of the unique identifier part
-- The **`domain-name`** part does not have to exist as a web server (HTTPS), but may do
-  - The uniqueness of the name is the domain name part that has to be registred at creation of the TEI.
-- The **`unique-identifier`** has to be unique within the `domain-name`. Recommendation is to use a UUID but it can be an existing article code too
-
 A TEI belongs to a single product. A product can have multiple TEIs - like one with a EAN
 barcode and one with the vendor's product number.
 
@@ -55,6 +63,12 @@ barcode and one with the vendor's product number.
 ```text
 urn:tei:<type>:<domain-name>:<unique-identifier>
 ````
+
+- The **`type`** which defines the syntax of the unique identifier part
+- The **`domain-name`** part does not have to exist as a web server (HTTPS), but may do
+  - The uniqueness of the name is the domain name part that has to be registred at creation of the TEI.
+- The **`unique-identifier`** has to be unique within the `domain-name`.
+  Recommendation is to use a UUID but it can be an existing article code too
 
 **Note**: this requires a registration of the TEI URN schema with IANA - [see here](https://github.com/CycloneDX/transparency-exchange-api/issues/18)
 
@@ -132,58 +146,76 @@ urn:tei:uuid:cyclonedx.org:d4d9f54a-abcf-11ee-ac79-1a52914d44b1
 - GS1
 - STD
 
-
 ### TEI resolution using DNS
 
-The name part of the TEI is used in a DNS query to find one or multiple locations for product transparency exchange information.
-At the URL we need a well-known name space to find out more
+The name part of the TEI is used in a DNS query to find one or multiple locations for
+product transparency exchange information. DNS can deliver load balancing and
+failover functionality to make sure that the information is always reachable.
+
+At the URL we need a well-known name space to find out where the API endpoint is hosted.
+This is solved by using the ".well-known" name space as defined by the IETF.
 
 - `urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1`
 - Syntax: `urn:tei:uuid:<name based on domain>:<unique identifier>`
 
 The name in the DNS name part points to a set of DNS records.
-A TEI with name “tex.example.com" queries for `_tei._tcp.tex.example.com URI records`.
-These point to URIs for the transparency exchange data.
-If there are no records, try to resolve the name (using AAAA and A DNS records) and
-append the /.well-known/tei prefix
+A TEI with name “tea.example.com" queries for `tea.example.com HTTPS records.
+These point to the hosts available for the Transparency Exchange API.
+Note that "tea.example.com" may not have A/AAAA records at all if it
+points to other servers, like "tea01.example.org" and "teahost.example.net".
 
-```dns
-_tei._tcp.tex.example.com.   3600 IN URI 10 1 “https://www.example.com/transparency“
+If there are no HTTPS records, try to resolve the name (using AAAA and A DNS records).
+
+After selecting a host and resolving that to IP address, the TEA client
+connects to the host using HTTPS with the original name, not the one found
+in DNS. The URI is composed of the name with the  "/.well-known/tea" prefix added.
+
+```text
+tea.example.com.   3600 IN HTTPS  1  tea01.prod.example.com.
 ```
 
-Example response of DNS query including multiple URIs with a priority
+Results in `https://tea.example.com/.well-known/tea/<identifier>` while connecting to
+the host tea01.prod.example.com.
 
-```dns
-_tei._tcp.tex.example.com.   3600 IN URI 10 1 “https://www.example.com/transparency“
-_tei._tcp.tex.example.com.   3600 IN URI 20 1 “https://backup.example.com/transparency“
-_tei._tcp.tex.example.com.   3600 IN URI 30 1 “https://thirdparty.example.org/example.com/transparency“
+### Load balancing and fail over
+
+Example zone:
+
+```text
+tea.example.com.   3600 IN HTTPS  10  tea01.prod.example.com.
+tea.example.com.   3600 IN HTTPS  10  tea02.prod.example.com.
+tea.example.com.   3600 IN HTTPS  20  tea03.prod.example.com.
 ```
 
-First try lowest priority then move up.
+In this case servers tea01 and tea02 will get 50% of the load each.
+If they are not reachable, tea03 will be used for failover.
 
 It is recommended to have a third party external repository as the last priority.
-The URI in DNS does not have to belong to the same domain as the URI records. I.e.
-it is valid for "tex.example.com" to resolve to "thirdparty.example.org".
 
 ### Finding the Index using DNS result
 
 Append the product part of the TEI to the URI found
 
 - TEI: `urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1`
-- DNS record: `_tei._tcp.products.example.com`
-- URI in DNS: `://www.example.com/transparency/`
-- URL: `https://www.example.com/transparency/d4d9f54a-abcf-11ee-ac79-1a52914d44b1/`
+- DNS record: `products.example.com`
+- Server found in DNS HTTPS record: `teapot.prod.example.com`
+- URL: `https://products.example.com/.well-known/tea/d4d9f54a-abcf-11ee-ac79-1a52914d44b1/`
+- HTTP 302 redirect to "https://teapot02.consumer.example.com/tea/v2/product-index/d4d9f54a-abcf-11ee-ac79-1a52914d44b1'
 
-If no DNS URI records are found the resolution defaults to A and AAAA records.
+The server at "teapot.prod.example.com" needs a TLS certificate including "products.example.com"
+in the subject alt name. "teapot02.consumer.example.com" needs a certificate with that
+host name.
+
+If no HTTPS records are found the resolution defaults to A and AAAA records.
 IP address is not valid in the domain name field.
 
-Append the URL prefix `/.well-known/tei/` of the TEI to the DNS name found
+Append the URL prefix `/.well-known/tea/` of the TEI to the DNS name found
 Always prefix with the https:// scheme. http (unencrypted) is not valid.
 
 - TEI: `urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1`
-- URL: `https://products.example.com/.well-known/tei/d4d9f54a-abcf-11ee-ac79-1a52914d44b1/`
+- URL: `https://products.example.com/.well-known/tea/d4d9f54a-abcf-11ee-ac79-1a52914d44b1/`
 
-**NOTE:** The `/.well-known/tei`names space needs to be registred.
+**NOTE:** The `/.well-known/tea`names space needs to be registred.
 
 ## The TEA Version Index
 
@@ -193,6 +225,6 @@ has many identifiers. The redirect should not lead to a separate web server.
 
 ## References
 
-- [RFC 7553 - THE DNS URI record](https://datatracker.ietf.org/doc/html/rfc7553)
+- [RFC 9640 - Service Binding and Parameter Specification via the DNS (SVCB and HTTPS Resource Records)](https://datatracker.ietf.org/doc/html/rfc9640)
 - [IANA .well-known registry](https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml)
 - [IANA URI registry](https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml#urn-namespaces-1)

--- a/discovery/readme.md
+++ b/discovery/readme.md
@@ -37,7 +37,7 @@ The TEI for a product can be communicated to the user in many ways.
 
 ## TEA Discovery - defining an extensible identifier
 
-TEA discovery is the process where a user with a product identifier can discover and download
+TEA discovery is the process where a user with a product identifier can discover and downloadg
 artifacts automatically, with or without authentication. A globally unique identifier is
 required for a given product. This identifier is called the Transparency Exchange Identifier (TEI).
 
@@ -159,6 +159,7 @@ This is solved by using the ".well-known" name space as defined by the IETF.
 - Syntax: `urn:tei:uuid:<name based on domain>:<unique identifier>`
 
 The name in the DNS name part points to a set of DNS records.
+
 A TEI with name `tea.example.com` queries for `tea.example.com` `HTTPS` records.
 These point to the hosts available for the Transparency Exchange API.
 Note that `tea.example.com` may not have `A`/`AAAA` records at all if it
@@ -178,6 +179,9 @@ Results in the base URI (without the product identifier)
 `https://tea.example.com/.well-known/tea/` while connecting to
 the host `tea01.prod.example.com`.
 
+Results in `https://tea.example.com/.well-known/tea/<identifier>` while connecting to
+the host tea01.prod.example.com.
+
 ### Load balancing and fail over
 
 Example zone:
@@ -188,8 +192,8 @@ tea.example.com.   3600 IN HTTPS  10  tea02.prod.example.com.
 tea.example.com.   3600 IN HTTPS  20  tea03.prod.example.com.
 ```
 
-In this case servers `tea01`and `tea02` will get 50% of the load each.
-If they are not reachable, `tea03` will be used for failover.
+In this case servers tea01 and tea02 will get 50% of the load each.
+If they are not reachable, tea03 will be used for failover.
 
 It is recommended to have a third party external repository as the last priority.
 


### PR DESCRIPTION
- Remove the DNS URI records as a few large DNS providers does not support them (and the RFC is informational)
- Clarify TLS certificate requirements (according to RFC 9640)
- Fix some markdown formatting (make markdownlint happy)