### PR TITLE
fix: `examples` incorrectly nested for `POST /leaf`

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -306,16 +306,16 @@
                                     "release_date",
                                     "pre_release"
                                 ]
-                            }
-                        },
-                        "examples": {
-                            "basic": {
-                                "summary": "Basic leaf creation",
-                                "value": {
-                                    "tea_product_identifier": "123e4567-e89b-12d3-a456-426614174000",
-                                    "product_version": "1.0.0",
-                                    "release_date": "2024-03-20T15:30:00Z",
-                                    "pre_release": false
+                            },
+                            "examples": {
+                                "basic": {
+                                    "summary": "Basic leaf creation",
+                                    "value": {
+                                        "tea_product_identifier": "123e4567-e89b-12d3-a456-426614174000",
+                                        "product_version": "1.0.0",
+                                        "release_date": "2024-03-20T15:30:00Z",
+                                        "pre_release": false
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Root cause of https://github.com/madpah/transparency-exchange-api/actions/runs/11933709569/job/33261312468