### PR TITLE
fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-* @oej
-* @madpah
+# see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+* @oej @madpah


### PR DESCRIPTION
there were 2 lines: 
```text
* @oej
* @madpah
```

The codeowners file is not additive. only the **last matching** one has an effect. see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
Since both lines matched `*`, only the last one was effective.
Therefore, `@oej` was never a code owner, only `@madpah` was.


I assume this was by mistake, and both were intended to be code owners.
this PR fixes the file to reflect this assumption.