### PR TITLE
Add example of TEA API

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Simple TEA service example
+
+A simple example of compliant TEA service backed by a filesystem.
+
+You can run the example using any web server with support for content negotiation, even a Python script:
+
+```shell
+./run-server.py
+```

--- a/examples/run-server.py
+++ b/examples/run-server.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+from http.server import SimpleHTTPRequestHandler
+import socketserver
+
+
+class JsonHTTPRequestHandler(SimpleHTTPRequestHandler):
+    def translate_path(self, path):
+        result = super().translate_path(path) + ".json"
+        # Windows doesn't allow `:` in file names
+        return result.replace(":", "%3A")
+
+
+PORT = 8000
+with socketserver.TCPServer(("", PORT), JsonHTTPRequestHandler) as httpd:
+    print("Service at port", PORT)
+    httpd.serve_forever()

--- a/examples/v1/collection.json
+++ b/examples/v1/collection.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "2024-03-20T15:30:00Z",
+  "page_start_index": 0,
+  "page_size": 2147483647,
+  "total_results": 3,
+  "content": [
+    {
+      "leaf_uuid": "b0d30215-04f0-462f-84d4-68fcff437f5e",
+      "uuid": "e697693d-2acf-42af-a0b9-6f85aa84ec10",
+      "collection_name": "Apache Log4j 1.2.17",
+      "collection_version": "1",
+      "release_date": "2015-08-15"
+    },
+    {
+      "leaf_uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+      "uuid": "673c62c8-ea5b-4a70-9012-5a8c00aab1e1",
+      "collection_name": "Apache Log4j 2.23.0",
+      "collection_version": "1",
+      "release_date": "2024-02-17"
+    },
+    {
+      "leaf_uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+      "uuid": "d750d933-38b2-46af-a8ad-71207ae2b56e",
+      "collection_name": "Apache Log4j 2.23.1",
+      "collection_version": "2",
+      "release_date": "2024-03-06"
+    }
+  ]
+}

--- a/examples/v1/collection/673c62c8-ea5b-4a70-9012-5a8c00aab1e1.json
+++ b/examples/v1/collection/673c62c8-ea5b-4a70-9012-5a8c00aab1e1.json
@@ -1,0 +1,37 @@
+{
+  "leaf_uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+  "uuid": "673c62c8-ea5b-4a70-9012-5a8c00aab1e1",
+  "collection_name": "Apache Log4j 2.23.0",
+  "collection_version": "1",
+  "release_date": "2024-02-17",
+  "author": {
+    "name": "John Doe",
+    "email": "john@example.com",
+    "organization": "The Apache Software Foundation"
+  },
+  "reason": "New Product Release",
+  "artifacts": [
+    {
+      "type": "bom",
+      "mime_type": "application/vnd.cyclonedx+xml",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.23.0/log4j-bom-2.23.0-cyclonedx.xml",
+      "checksums": [
+        {
+          "type": "SHA1",
+          "value": "5f81bb0da6e60a3214b6eacdef3f697a5bb3fad0"
+        }
+      ]
+    },
+    {
+      "type": "vulnerability-assertion",
+      "mime_type": "application/vnd.cyclonedx+xml",
+      "url": "https://logging.apache.org/cyclonedx/urn:cdx:dfa35519-9734-4259-bba1-3e825cf4be06/2.xml",
+      "checksums": [
+        {
+          "type": "SHA256",
+          "value": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/v1/collection/d750d933-38b2-46af-a8ad-71207ae2b56e.json
+++ b/examples/v1/collection/d750d933-38b2-46af-a8ad-71207ae2b56e.json
@@ -1,0 +1,37 @@
+{
+  "leaf_uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+  "uuid": "d750d933-38b2-46af-a8ad-71207ae2b56e",
+  "collection_name": "Apache Log4j 2.23.1",
+  "collection_version": "2",
+  "release_date": "2024-03-06",
+  "author": {
+    "name": "John Doe",
+    "email": "john@example.com",
+    "organization": "The Apache Software Foundation"
+  },
+  "reason": "New Product Release",
+  "artifacts": [
+    {
+      "type": "bom",
+      "mime_type": "application/vnd.cyclonedx+xml",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-bom/2.23.1/log4j-bom-2.23.1-cyclonedx.xml",
+      "checksums": [
+        {
+          "type": "SHA1",
+          "value": "7508931879d04ae497e683eb3abe15376e930c8b"
+        }
+      ]
+    },
+    {
+      "type": "vulnerability-assertion",
+      "mime_type": "application/vnd.cyclonedx+xml",
+      "url": "https://logging.apache.org/cyclonedx/urn:cdx:dfa35519-9734-4259-bba1-3e825cf4be06/2.xml",
+      "checksums": [
+        {
+          "type": "SHA256",
+          "value": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/v1/collection/e697693d-2acf-42af-a0b9-6f85aa84ec10.json
+++ b/examples/v1/collection/e697693d-2acf-42af-a0b9-6f85aa84ec10.json
@@ -1,0 +1,13 @@
+{
+  "leaf_uuid": "b0d30215-04f0-462f-84d4-68fcff437f5e",
+  "uuid": "e697693d-2acf-42af-a0b9-6f85aa84ec10",
+  "collection_name": "Apache Log4j 1.2.17",
+  "collection_version": "1",
+  "release_date": "2024-02-17",
+  "author": {
+    "name": "John Doe",
+    "email": "john@example.com",
+    "organization": "The Apache Software Foundation"
+  },
+  "reason": "New Product Release"
+}

--- a/examples/v1/leaf.json
+++ b/examples/v1/leaf.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "2024-03-20T15:30:00Z",
+  "page_start_index": 0,
+  "page_size": 2147483647,
+  "total_results": 2,
+  "content": [
+    {
+      "product_uuid": "18736afd-7ac1-4b6b-b284-03495bf83289",
+      "uuid": "b0d30215-04f0-462f-84d4-68fcff437f5e",
+      "leaf_name": "Apache Log4j 1.2",
+      "leaf_version": "1.2"
+    },
+    {
+      "product_uuid": "96575f2d-ec70-445c-957e-543de92b70b3",
+      "uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+      "leaf_name": "Apache Log4j 2.23",
+      "leaf_version": "2.23"
+    }
+  ]
+}

--- a/examples/v1/leaf/1e7d13f3-4c65-40f1-a990-8b85079b2347.json
+++ b/examples/v1/leaf/1e7d13f3-4c65-40f1-a990-8b85079b2347.json
@@ -1,0 +1,22 @@
+{
+  "product_uuid": "96575f2d-ec70-445c-957e-543de92b70b3",
+  "uuid": "1e7d13f3-4c65-40f1-a990-8b85079b2347",
+  "leaf_name": "Apache Log4j 2.23",
+  "leaf_version": "2.23",
+  "cle": [
+    {
+      "type": "generalAvailability",
+      "effective": "2024-02-17",
+      "ranges": [
+        "vers:maven/>=2.23|<2.24"
+      ]
+    },
+    {
+      "type": "endOfSupport",
+      "effective": "2024-09-03",
+      "ranges": [
+        "vers:maven/>=2.23|<2.24"
+      ]
+    }
+  ]
+}

--- a/examples/v1/leaf/b0d30215-04f0-462f-84d4-68fcff437f5e.json
+++ b/examples/v1/leaf/b0d30215-04f0-462f-84d4-68fcff437f5e.json
@@ -1,0 +1,22 @@
+{
+  "product_uuid": "18736afd-7ac1-4b6b-b284-03495bf83289",
+  "uuid": "b0d30215-04f0-462f-84d4-68fcff437f5e",
+  "leaf_name": "Apache Log4j 1.2",
+  "leaf_version": "1.2",
+  "cle": [
+    {
+      "type": "generalAvailability",
+      "effective": "2002-05-01",
+      "ranges": [
+        "vers:maven/>=1.2|<1.3"
+      ]
+    },
+    {
+      "type": "endOfSupport",
+      "effective": "2015-08-15",
+      "ranges": [
+        "vers:maven/>=1.2|<1.3"
+      ]
+    }
+  ]
+}

--- a/examples/v1/product.json
+++ b/examples/v1/product.json
@@ -1,0 +1,64 @@
+{
+  "timestamp": "2024-03-20T15:30:00Z",
+  "page_start_index": 0,
+  "page_size": 2147483647,
+  "total_results": 2,
+  "content": [
+    {
+      "uuid": "18736afd-7ac1-4b6b-b284-03495bf83289",
+      "product_name": "Apache Log4j 1",
+      "identifiers": [
+        {
+          "type": "tei",
+          "value": "urn:tei:dns:apache.org:logging-log4j1"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/log4j/log4j"
+        },
+        {
+          "type": "cpe",
+          "value": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+        }
+      ]
+    },
+    {
+      "uuid": "96575f2d-ec70-445c-957e-543de92b70b3",
+      "product_name": "Apache Log4j 2",
+      "identifiers": [
+        {
+          "type": "tei",
+          "value": "urn:tei:dns:apache.org:logging-log4j2"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/log4j-api"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/log4j-core"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/log4j-layout-template-json"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/slf4j-to-log4j-api"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/jul-to-log4j-api"
+        },
+        {
+          "type": "purl",
+          "value": "pkg:maven/org.apache.logging.log4j/jpl-to-log4j-api"
+        },
+        {
+          "type": "cpe",
+          "value": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/v1/product/urn%3Atei%3Adns%3Aapache.org%3Alogging-log4j1.json
+++ b/examples/v1/product/urn%3Atei%3Adns%3Aapache.org%3Alogging-log4j1.json
@@ -1,0 +1,1 @@
+urn%3Auuid%3A18736afd-7ac1-4b6b-b284-03495bf83289.json

--- a/examples/v1/product/urn%3Atei%3Adns%3Aapache.org%3Alogging-log4j2.json
+++ b/examples/v1/product/urn%3Atei%3Adns%3Aapache.org%3Alogging-log4j2.json
@@ -1,0 +1,1 @@
+urn%3Auuid%3A96575f2d-ec70-445c-957e-543de92b70b3.json

--- a/examples/v1/product/urn%3Auuid%3A18736afd-7ac1-4b6b-b284-03495bf83289.json
+++ b/examples/v1/product/urn%3Auuid%3A18736afd-7ac1-4b6b-b284-03495bf83289.json
@@ -1,0 +1,34 @@
+{
+  "uuid": "18736afd-7ac1-4b6b-b284-03495bf83289",
+  "product_name": "Apache Log4j 1",
+  "identifiers": [
+    {
+      "type": "tei",
+      "value": "urn:tei:dns:apache.org:logging-log4j1"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/log4j/log4j"
+    },
+    {
+      "type": "cpe",
+      "value": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+    }
+  ],
+  "cle": [
+    {
+      "type": "generalAvailability",
+      "effective": "2001-01-08",
+      "ranges": [
+        "vers:maven/>=1|<2"
+      ]
+    },
+    {
+      "type": "endOfLife",
+      "effective": "2015-08-15",
+      "ranges": [
+        "vers:maven/>=1|<2"
+      ]
+    }
+  ]
+}

--- a/examples/v1/product/urn%3Auuid%3A96575f2d-ec70-445c-957e-543de92b70b3.json
+++ b/examples/v1/product/urn%3Auuid%3A96575f2d-ec70-445c-957e-543de92b70b3.json
@@ -1,0 +1,47 @@
+{
+  "uuid": "96575f2d-ec70-445c-957e-543de92b70b3",
+  "product_name": "Apache Log4j 2",
+  "identifiers": [
+    {
+      "type": "tei",
+      "value": "urn:tei:dns:apache.org:logging-log4j2"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/log4j-api"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/log4j-core"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/log4j-layout-template-json"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/slf4j-to-log4j-api"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/jul-to-log4j-api"
+    },
+    {
+      "type": "purl",
+      "value": "pkg:maven/org.apache.logging.log4j/jpl-to-log4j-api"
+    },
+    {
+      "type": "cpe",
+      "value": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+    }
+  ],
+  "cle": [
+    {
+      "type": "generalAvailability",
+      "effective": "2014-07-12",
+      "ranges": [
+        "vers:maven/>=2|<3"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This adds an example of statically generated TEA service.

This example does **not** follow the currently published OpenAPI, but tries to be up-to-date with the [Koala Work Camp](https://docs.google.com/document/d/1tbLuEyEj5XsexfWcA1tLUxqZwIZwmldGwhFi3q9Sm1M/edit) calls.