### PR TITLE
fix: Refer to OpenAPI Spec in YAML format

### DIFF
--- a/spec/generators/common.yaml
+++ b/spec/generators/common.yaml
@@ -1,4 +1,4 @@
-inputSpec: /local/spec/openapi.json
+inputSpec: /local/spec/openapi.yaml
 gitUserId: CycloneDX
 gitRepoId: transparency-exchange-api
 


### PR DESCRIPTION
Noted a discrepancy that was causing generation of test API client libraries to fail.