### PR TITLE
feat: use `camelCase` for property and parameter names

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -343,9 +343,9 @@ components:
           "$ref": "#/components/schemas/uuid"
         version:
           type: string
-        release_date:
+        releaseDate:
           "$ref": "#/components/schemas/date-time"
-        pre_release:
+        preRelease:
           type: boolean
           description: Marks if the version is a pre-release version
         identifiers:
@@ -371,9 +371,9 @@ components:
         version:
           type: integer
           description: Collection version, incremented each time its content changes.
-        release_date:
+        releaseDate:
           "$ref": "#/components/schemas/date-time"
-        update_reason:
+        updateReason:
           "$ref": "#/components/schemas/collection-update-reason"
         artifacts:
           type: array
@@ -493,7 +493,7 @@ components:
           type: string
           description: A download URL for the artifact
           format: url
-        signature_url:
+        signatureUrl:
           type: string
           description: A download URL for an external signature of the artifact
           format: url
@@ -536,22 +536,22 @@ components:
           type: string
           format: date-time
           example: '2024-03-20T15:30:00Z'
-        page_start_index:
+        pageStartIndex:
           type: number
           format: int64
           default: 0
-        page_size:
+        pageSize:
           type: number
           format: int64
           default: 100
-        total_results:
+        totalResults:
           type: number
           format: int64
       required:
         - timestamp
-        - page_start_index
-        - page_size
-        - total_results
+        - pageStartIndex
+        - pageSize
+        - totalResults
   responses:
     204-common-delete:
       description: Object deleted successfully
@@ -585,7 +585,7 @@ components:
   parameters:
     # Pagination
     page-offset:
-      name: page-offset
+      name: pageOffset
       description: Pagination offset
       in: query
       required: false
@@ -594,7 +594,7 @@ components:
         format: int64
         default: 0
     page-size:
-      name: page-size
+      name: pageSize
       description: Pagination offset
       in: query
       required: false
@@ -604,7 +604,7 @@ components:
         default: 100
     # Identifiers
     tei_urn:
-      name: tei_urn
+      name: teiUrn
       description: Transparency Exchange Identifier (URN)
       in: query
       required: true

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -340,14 +340,19 @@ components:
       type: object
       properties:
         uuid:
+          description: A unique identifier for the TEA Component Release
           "$ref": "#/components/schemas/uuid"
         version:
+          description: Version number
           type: string
         releaseDate:
+          description: Timestamp of the release (for sorting purposes)
           "$ref": "#/components/schemas/date-time"
         preRelease:
           type: boolean
-          description: Marks if the version is a pre-release version
+          description: |
+            A flag indicating pre-release (or beta) status.
+            May be disabled after the creation of the release object, but can't be enabled after creation of an object.
         identifiers:
           type: array
           description: List of identifiers for the component
@@ -358,6 +363,30 @@ components:
         - uuid
         - version
         - releaseDate
+      examples:
+        # Apache Tomcat 11.0.6
+        - uuid: 605d0ecb-1057-40e4-9abf-c400b10f0345
+          version: "11.0.6"
+          releaseDate: 2025-04-01T15:43:00Z
+          identifiers:
+            - idType: purl
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6
+        # Different release of Apache Tomcat
+        - uuid: da89e38e-95e7-44ca-aa7d-f3b6b34c7fab
+          version: "10.1.40"
+          releaseDate: 2025-04-01T18:20:00Z
+          identifiers:
+            - idType: purl
+              idValue: pkg:maven/org.apache.tomcat/tomcat@10.1.40
+        # A pre-release of Apache Tomcat
+        - uuid: 95f481df-f760-47f4-b2f2-f8b76d858450
+          version: "11.0.0-M26"
+          releaseDate: 2024-09-13T17:49:00Z
+          preRelease: true
+          identifiers:
+            - idType: purl
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26
+
     #
     # TEA Collection and related objects
     #

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -357,7 +357,7 @@ components:
       required:
         - uuid
         - version
-        - release_date
+        - releaseDate
     #
     # TEA Collection and related objects
     #
@@ -366,24 +366,66 @@ components:
       description: A collection of security-related documents
       properties:
         uuid:
+          description: |
+            UUID of the TEA Collection object.
+            Note that this is equal to the UUID of the associated TEA Component Release object.
+            When updating a collection, only the `version` is changed.
           "$ref": "#/components/schemas/uuid"
-          description: Must match the UUID of the corresponding `release` object
         version:
           type: integer
-          description: Collection version, incremented each time its content changes.
+          description: |
+            TEA Collection version, incremented each time its content changes.
+            Versions start with 1.
         releaseDate:
+          description: TEA Collection version release date.
           "$ref": "#/components/schemas/date-time"
         updateReason:
+          description: Reason for the update/release of the TEA Collection object.
           "$ref": "#/components/schemas/collection-update-reason"
         artifacts:
           type: array
+          description: List of TEA artifact objects.
           items:
             "$ref": "#/components/schemas/artifact"
+      examples:
+        # Documents in the latest release of Log4j Core
+        - uuid: 4c72fe22-9d83-4c2f-8eba-d6db484f32c8
+          version: 1
+          releaseDate: 2024-12-13T00:00:00Z
+          updateReason:
+            type: ARTIFACT_UPDATED
+            comment: VDR file updated
+          artifacts:
+            - uuid: 1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce
+              name: Build SBOM
+              type: bom
+              formats:
+                - mime_type: application/vnd.cyclonedx+xml
+                  description: CycloneDX SBOM (XML)
+                  url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml
+                  signature_url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc
+                  checksums:
+                    - algType: MD5
+                      algValue: 2e1a525afc81b0a8ecff114b8b743de9
+                    - algType: SHA-1
+                      algValue: 5a7d4caef63c5c5ccdf07c39337323529eb5a770
+            - uuid: dfa35519-9734-4259-bba1-3e825cf4be06
+              name: Vulnerability Disclosure Report
+              type: vulnerability-assertion
+              formats:
+                - mime_type: application/vnd.cyclonedx+xml
+                  description: CycloneDX VDR (XML)
+                  url: https://logging.apache.org/cyclonedx/vdr.xml
+                  checksums:
+                    - algType: SHA-256
+                      algValue: 75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a
+
     collection-update-reason:
       type: object
       description: Reason for the update to the TEA collection
       properties:
         type:
+          description: Type of update reason.
           "$ref": "#/components/schemas/collection-update-reason-type"
         comment:
           type: string
@@ -406,16 +448,22 @@ components:
       description: A security-related document
       properties:
         uuid:
+          description: UUID of the TEA Artifact object.
           "$ref": "#/components/schemas/uuid"
         name:
           type: string
           description: Artifact name
         author:
+          description: Author of the TEA Artifact object
           "$ref": "#/components/schemas/artifact-author"
         type:
+          description: Type of artifact
           "$ref": "#/components/schemas/artifact-type"
         formats:
           type: array
+          description: |
+            List of objects with the same content, but in different formats.
+            The order of the list has no significance.
           items:
             "$ref": "#/components/schemas/artifact-format"
     artifact-author:
@@ -483,7 +531,7 @@ components:
       type: object
       description: A security-related document in a specific format
       properties:
-        mimeType:
+        mime_type:
           type: string
           description: The MIME type of the document
         description:
@@ -491,11 +539,11 @@ components:
           description: A free text describing the artifact
         url:
           type: string
-          description: A download URL for the artifact
+          description: Direct download URL for the artifact
           format: url
         signatureUrl:
           type: string
-          description: A download URL for an external signature of the artifact
+          description: Direct download URL for an external signature of the artifact
           format: url
         checksums:
           type: array
@@ -506,6 +554,7 @@ components:
       type: object
       properties:
         algType:
+          description: Checksum algorithm
           "$ref": "#/components/schemas/artifact-checksum-type"
         algValue:
           type: string

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -2,18 +2,73 @@
 
 ## The TEA release object (TRO)
 
-The TEA Component Release object is a list of releases (versions) of a component
-with a release identifier (string), release timestamp and a lifecycle
-enumeration for the release. Each release includes a UUID of a 
-TEA Collection object (TCO).
+The TEA Component Release object corresponds to a specific variant
+(version) of a component with a release identifier (string),
+release timestamp and a lifecycle enumeration for the release.
+The UUID of the TEA Component Release object matches the UUID of the associated TEA Collection objects (TCO).
 
-* UUID: Release UUID
-* Version: Version (string)
-* Date: Timestamp of release (for sorting releases)
-* Prerelease: A flag indicating pre-release (or beta) status. May be disabled
-  after creation of release object, but can't be enabled after creation of
-  an object.
-* Lifecycle: An identifier indicating lifecycle status of a release
+A TEA Component Release object has the following parts:
+
+- __uuid__: A unique identifier for the TEA Component Release
+- __version__: Version number
+- __releaseDate__: Timestamp of the release (for sorting purposes)
+- __preRelease__: A flag indicating pre-release (or beta) status.
+  May be disabled after the creation of the release object, but can't be enabled after creation of an object.
+- __identifiers__: List of identifiers for the component
+  - __idType__: Type of identifier, e.g. `tei`, `purl`, `cpe`
+  - __idValue__: Identifier value
+
+### Examples
+
+A TEA Component Release object of the binary distribution of Apache Tomcat 11.0.6 will look like:
+
+```json
+{
+  "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
+  "version": "11.0.6",
+  "releaseDate": "2025-04-01T15:43:00Z",
+  "identifiers": [
+    {
+      "idType": "purl",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6"
+    }
+  ]
+}
+```
+
+Different versions of Apache Tomcat should have separate TEA Component Release objects:
+
+```json
+{
+  "uuid": "da89e38e-95e7-44ca-aa7d-f3b6b34c7fab",
+  "version": "10.1.4",
+  "releaseDate": "2025-04-01T18:20:00Z",
+  "identifiers": [
+    {
+      "idType": "purl",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@10.1.4"
+    }
+  ]
+}
+```
+
+The pre-release flag is used to mark versions not production ready
+and does not require users to know the version naming scheme adopted by the project.
+
+```json
+{
+  "uuid": "95f481df-f760-47f4-b2f2-f8b76d858450",
+  "version": "11.0.0-M26",
+  "releaseDate": "2024-09-13T17:49:00Z",
+  "preRelease": true,
+  "identifiers": [
+    {
+      "idType": "purl",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
+    }
+  ]
+}
+```
 
 ## The TEA Collection object (TCO)
 

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -50,56 +50,111 @@ to implement this:
 
 ### Collection object
 
-The TEA Collection object has the following parts
+The TEA Collection object has the following parts:
 
-* Preamble
-  * UUID of the TEA collection release object (TCO). Note that this
-    is the same UUID as the release object for this version. When updating
-    a collection, the version is changed.
-  * Product Release date (timestamp)
-  * Collection version release date (timestamp)
-  * _Version_ of this collection object. Starting with 1.
-  * Reason for update/release of TCO
-    * ENUM reason
-      See below
-    * clear text description of change
-      * "New product release"
-      * "Corrected dependency in SBOM that was faulty"
-      * "Added missing In-Toto build attestation"
-* List of artifact objects (see below)
-* Optional Signature of the collection object
+- Preamble
+  - __uuid__: UUID of the TEA Collection object.
+    Note that this is equal to the UUID of the associated TEA Component Release object.
+    When updating a collection, only the `version` is changed.
+  - __version__: TEA Collection version, incremented each time its content changes.
+    Versions start with 1.
+  - __releaseDate__: TEA Collection version release date.
+  - __updateReason__: Reason for the update/release of the TEA Collection object.
+    - __type__: Type of update reason.
+      See [reasons for TEA Collection update](#the-reason-for-tco-update-enum) below.
+    - __comment__: Free text description.
+- __artifacts__: List of TEA artifact objects.
+  See [below](#artifact-object).
 
-The artifact object has the following parts
+### Artifact object
 
-* Artifact UUID
-* Artifact name
-* Author of the artifact object
-  * Name
-  * Email
-  * Organisation
-* List of objects with the same content, but in different formats.
+The TEA Artifact object has the following parts:
+
+- __uuid__: UUID of the TEA Artifact object.
+- __name__: Artifact name.
+- __author__: Author of the TEA Artifact object:
+  - __name__: The name of the author.
+  - __email__: The e-mail address of the author.
+  - __organization__: Organization
+- __type__: Type of artifact.
+  See [TEA Artifact types](../tea-artifact/tea-artifact.md) for a list.
+- __formats__: List of objects with the same content, but in different formats.
   The order of the list has no significance.
-  * UUID for subdoc
-  * Optional BOM identifier
-    * SPDX or CycloneDX reference to BOM
-  * MIME media type
-  * Artifact category (enum)
-    * <https://cyclonedx.org/docs/1.6/json/#externalReferences_items_type>
-  * Description in clear text
-  * Direct URL for downloads of artefact
-  * Direct URL for download of external signature
-  * Size in bytes
-  * SHA384 checksum
+  - __mime_type__: The MIME type of the document
+  - __description__: A free text describing the artifact
+  - __url__: Direct download URL for the artifact
+  - __signature_url__: Direct download URL for an external signature of the artifact
+  - __checksums__: List of checksums for the artifact
+    - __algType__: Checksum algorithm
+      See [CycloneDX checksum algorithms](https://cyclonedx.org/docs/1.6/json/#components_items_hashes_items_alg) for a list of supported values.
+    - __algValue__: Checksum value
 
 ### The reason for TCO update enum
 
-| ENUM        | Explanation                    |
-|-------------|--------------------------------|
-| INITIAL_RELEASE | Initial release of the collection |
-| VEX_UPDATED   | Updated the VEX artifact(s)    |
-| ARTIFACT_UPDATED  | Updated the artifact(s) other than VEX |
-| ARTIFACT_REMOVED | Removal of artifact       |
-| ARTIFACT_ADDED | Addition of an artifact |
+| ENUM             | Explanation                            |
+|------------------|----------------------------------------|
+| INITIAL_RELEASE  | Initial release of the collection      |
+| VEX_UPDATED      | Updated the VEX artifact(s)            |
+| ARTIFACT_UPDATED | Updated the artifact(s) other than VEX |
+| ARTIFACT_REMOVED | Removal of artifact                    |
+| ARTIFACT_ADDED   | Addition of an artifact                |
 
 Updates of VEX (CSAF) files may be handled in a different way by a TEA client,
 producing different alerts than other changes of a collection.
+
+### Examples
+
+```json
+{
+  "uuid": "4c72fe22-9d83-4c2f-8eba-d6db484f32c8",
+  "version": 1,
+  "releaseDate": "2024-12-13T00:00:00Z",
+  "updateReason": {
+    "type": "ARTIFACT_UPDATED",
+    "comment": "VDR file updated"
+  },
+  "artifacts": [
+    {
+      "uuid": "1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce",
+      "name": "Build SBOM",
+      "type": "bom",
+      "formats": [
+        {
+          "mime_type": "application/vnd.cyclonedx+xml",
+          "description": "CycloneDX SBOM (XML)",
+          "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml",
+          "signature_url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc",
+          "checksums": [
+            {
+              "algType": "MD5",
+              "algValue": "2e1a525afc81b0a8ecff114b8b743de9"
+            },
+            {
+              "algType": "SHA-1",
+              "algValue": "5a7d4caef63c5c5ccdf07c39337323529eb5a770"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "dfa35519-9734-4259-bba1-3e825cf4be06",
+      "name": "Vulnerability Disclosure Report",
+      "type": "vulnerability-assertion",
+      "formats": [
+        {
+          "mime_type": "application/vnd.cyclonedx+xml",
+          "description": "CycloneDX VDR (XML)",
+          "url": "https://logging.apache.org/cyclonedx/vdr.xml",
+          "checksums": [
+            {
+              "algType": "SHA-256",
+              "algValue": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```


### PR DESCRIPTION
This PR tries to uniformize the naming strategy for JSON properties and parameter names. Since CycloneDX mostly uses `camelCase` instead of `snake_case` or `kebab-case`, I settled to convert everything to camel case.

**Note**: The names that are used internally (e.g., JSON schemas and parameter references) were not modified.