### PR TITLE
fix: remove `author` for specification

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -484,9 +484,6 @@ components:
         name:
           type: string
           description: Artifact name
-        author:
-          description: Author of the TEA Artifact object
-          "$ref": "#/components/schemas/artifact-author"
         type:
           description: Type of artifact
           "$ref": "#/components/schemas/artifact-type"
@@ -497,20 +494,6 @@ components:
             The order of the list has no significance.
           items:
             "$ref": "#/components/schemas/artifact-format"
-    artifact-author:
-      type: object
-      description: The author of a document.
-      properties:
-        name:
-          type: string
-          description: The name of the author
-        email:
-          type: string
-          description: The e-mail address of the author
-          format: email
-        organization:
-          type: string
-          description: Organization
     artifact-type:
       type: string
       description: Specifies the type of external reference.

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -127,10 +127,6 @@ The TEA Artifact object has the following parts:
 
 - __uuid__: UUID of the TEA Artifact object.
 - __name__: Artifact name.
-- __author__: Author of the TEA Artifact object:
-  - __name__: The name of the author.
-  - __email__: The e-mail address of the author.
-  - __organization__: Organization
 - __type__: Type of artifact.
   See [TEA Artifact types](../tea-artifact/tea-artifact.md) for a list.
 - __formats__: List of objects with the same content, but in different formats.


### PR DESCRIPTION
This removes the `author` field from the collection.

Fixes #139