### PR TITLE
feat: trim down TEA Artifact types

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -498,49 +498,17 @@ components:
       type: string
       description: Specifies the type of external reference.
       enum:
-        - vcs
-        - issue-tracker
-        - website
-        - advisories
-        - bom
-        - mailing-list
-        - social
-        - chat
-        - documentation
-        - support
-        - source-distribution
-        - distribution
-        - distribution-intake
-        - license
-        - build-meta
-        - build-system
-        - release-notes
-        - security-contact
-        - model-card
-        - log
-        - configuration
-        - evidence
-        - formulation
-        - attestation
-        - threat-model
-        - adversary-model
-        - risk-assessment
-        - vulnerability-assertion
-        - exploitability-statement
-        - pentest-report
-        - static-analysis-report
-        - dynamic-analysis-report
-        - runtime-analysis-report
-        - component-analysis-report
-        - maturity-report
-        - certification-report
-        - codified-infrastructure
-        - quality-metrics
-        - poam
-        - electronic-signature
-        - digital-signature
-        - rfc-9116
-        - other
+        - ATTESTATION
+        - BOM
+        - BUILD_META
+        - CERTIFICATION
+        - FORMULATION
+        - LICENSE
+        - RELEASE_NOTES
+        - SECURITY_TXT
+        - THREAT_MODEL
+        - VULNERABILITIES
+        - OTHER
     artifact-format:
       type: object
       description: A security-related document in a specific format

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -128,7 +128,7 @@ The TEA Artifact object has the following parts:
 - __uuid__: UUID of the TEA Artifact object.
 - __name__: Artifact name.
 - __type__: Type of artifact.
-  See [TEA Artifact types](../tea-artifact/tea-artifact.md) for a list.
+  See [TEA Artifact types](#tea-artifact-types) for a list.
 - __formats__: List of objects with the same content, but in different formats.
   The order of the list has no significance.
   - __mime_type__: The MIME type of the document
@@ -142,7 +142,7 @@ The TEA Artifact object has the following parts:
 
 ### The reason for TCO update enum
 
-| ENUM             | Explanation                            |
+| ENUM             | Description                            |
 |------------------|----------------------------------------|
 | INITIAL_RELEASE  | Initial release of the collection      |
 | VEX_UPDATED      | Updated the VEX artifact(s)            |
@@ -152,6 +152,22 @@ The TEA Artifact object has the following parts:
 
 Updates of VEX (CSAF) files may be handled in a different way by a TEA client,
 producing different alerts than other changes of a collection.
+
+### TEA Artifact types
+
+| ENUM            | Description                                                                         |
+|-----------------|-------------------------------------------------------------------------------------|
+| ATTESTATION     | Machine-readable statements containing facts, evidence, or testimony.               |
+| BOM             | Bill of Materials: SBOM, OBOM, HBOM, SaaSBOM, etc.                                  |
+| BUILD_META      | Build-system specific metadata file: `pom.xml`, `package.json`, `.nuspec`, etc.     |
+| CERTIFICATION   | Industry, regulatory, or other certification from an accredited certification body. |
+| FORMULATION     | Describes how a component or service was manufactured or deployed.                  |
+| LICENSE         | License file                                                                        |
+| RELEASE_NOTES   | Release notes document                                                              |
+| SECURITY_TXT    | A `security.txt` file                                                               |
+| THREAT_MODEL    | A threat model                                                                      |
+| VULNERABILITIES | A list of vulnerabilities: VDR/VEX                                                  |
+| OTHER           | Document that does not fall into any of the above categories                        |
 
 ### Examples
 


### PR DESCRIPTION
Many of the [CycloneDX external reference](https://cyclonedx.org/docs/1.6/json/#externalReferences_items_type) types, such as `website` are not very interesting from a security perspective. Since it is easier to add new types than to remove them, this PR trims down the current list to some categories that:

- Should be interesting to access on a TEA server.
- Have machine-readable formats (with a few exceptions).