### PR TITLE
Fixes Swagger API documentation in light of move to YAML from JSON

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -10,7 +10,7 @@ work during our meetings and workshops. They are noted here in alphabetic order:
 * Anthony Harrison, APH10, United Kingdom
 * Olle E. Johansson, Project lead, Edvina AB, Sweden, oej@edvina.net
 * Mark Symons
-* Paul Horton
+* Paul Horton, Sonatype Inc., paul.horton@owasp.org, [@madaph](https://github.com/madpah)
 * Pavel Shukhman, Reliza, Canada, pavel@reliza.io
 * Piotr P. Karwasz, The Apache Software Foundation, pkarwasz-ecma@apache.org
 * Steve Springett

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,6 +1,6 @@
 # TEA OpenAPI Spec
 
-The OpenAPI 3.1 specification for the Transparency Exchange API is available in [openapi.json](./openapi.json).
+The OpenAPI 3.1 specification for the Transparency Exchange API is available in [openapi.yaml](./openapi.yaml).
 
 - [Generating API Clients from OpenAPI Spec](#generating-api-clients-from-openapi-spec)
 
@@ -23,7 +23,7 @@ Fire up the `swagger-ui` with Docker from the root of the repository:
 ```bash
 docker run \
     -p 8080:8080 \
-    -e SWAGGER_JSON=/koala/spec/openapi.json \
+    -e SWAGGER_JSON=/koala/spec/openapi.yaml \
     -v $(pwd):/koala swaggerapi/swagger-ui
 ```
 


### PR DESCRIPTION
The documentation referenced the old JSON format rather than the new YAML file.