### PR TITLE
feat: add TEA Release formats

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -360,26 +360,62 @@ components:
           description: List of identifiers for the component
           items:
             "$ref": "#/components/schemas/identifier"
+        formats:
+          type: array
+          description: List of different formats of this component release
+          items:
+            "$ref": "#/components/schemas/release-format"
         # add lifecycle here
       required:
         - uuid
         - version
         - releaseDate
       examples:
-        # Apache Tomcat 11.0.6
+        # Apache Tomcat 11.0.7
         - uuid: 605d0ecb-1057-40e4-9abf-c400b10f0345
-          version: "11.0.6"
-          releaseDate: 2025-04-01T15:43:00Z
+          version: "11.0.7"
+          releaseDate: 2025-05-07T18:08:00Z
           identifiers:
             - idType: PURL
-              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6
-        # Different release of Apache Tomcat
-        - uuid: da89e38e-95e7-44ca-aa7d-f3b6b34c7fab
-          version: "10.1.40"
-          releaseDate: 2025-04-01T18:20:00Z
-          identifiers:
-            - idType: PURL
-              idValue: pkg:maven/org.apache.tomcat/tomcat@10.1.40
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.7
+          formats:
+            - id: zip
+              description: Core binary distribution, zip archive
+              identifiers:
+                - idType: PURL
+                  idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=zip
+              checksums:
+                - algType: SHA_256
+                  algValue: 9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1
+              url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip
+              signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc
+            - id: tar.gz
+              description: Core binary distribution, tar.gz archive
+              identifiers:
+                - idType: PURL
+                  idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=tar.gz
+              checksums:
+                - algType: SHA_256
+                  algValue: 2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9
+              url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz
+              signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz.asc
+            - id: windows-x64
+              description: Core binary distribution, Windows x64 zip archive
+              identifiers:
+                - idType: PURL
+                  idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?classifier=windows-x64&type=zip
+              checksums:
+                - algType: SHA_256
+                  algValue: 62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4
+              url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6-windows-x64.zip
+              signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc
+            - id: windows-msi
+              description: Core binary distribution, Windows Service Installer (MSI)
+              checksums:
+                - algType: SHA_512
+                  algValue: 1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96
+              url: https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe
+              signatureUrl: https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc
         # A pre-release of Apache Tomcat
         - uuid: 95f481df-f760-47f4-b2f2-f8b76d858450
           version: "11.0.0-M26"
@@ -388,6 +424,74 @@ components:
           identifiers:
             - idType: PURL
               idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26
+    release-format:
+      type: object
+      properties:
+        id:
+          type: string
+          description: A short name for this release format
+        description:
+          type: string
+          description: A free text describing the component variant
+        identifiers:
+          type: array
+          description: List identifiers for this release format
+          items:
+            $ref: "#/components/schemas/identifier"
+        url:
+          type: string
+          description: Direct download URL for the release format
+          format: url
+        signatureUrl:
+          type: string
+          description: Direct download URL for an external signature of the release format
+          format: url
+        checksums:
+          type: array
+          description: List of checksums for the release format
+          items:
+            "$ref": "#/components/schemas/checksum"
+      required:
+        - id
+      examples:
+        - id: zip
+          description: Core binary distribution, zip archive
+          identifiers:
+            - idType: PURL
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=zip
+          checksums:
+            - algType: SHA_256
+              algValue: 9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1
+          url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip
+          signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc
+        - id: tar.gz
+          description: Core binary distribution, tar.gz archive
+          identifiers:
+            - idType: PURL
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=tar.gz
+          checksums:
+            - algType: SHA_256
+              algValue: 2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9
+          url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz
+          signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz.asc
+        - id: windows-x64
+          description: Core binary distribution, Windows x64 zip archive
+          identifiers:
+            - idType: PURL
+              idValue: pkg:maven/org.apache.tomcat/tomcat@11.0.6?classifier=windows-x64&type=zip
+          checksums:
+            - algType: SHA_256
+              algValue: 62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4
+          url: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6-windows-x64.zip
+          signatureUrl: https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc
+        - id: windows-msi
+          description: Core binary distribution, Windows Service Installer (MSI)
+          checksums:
+            - algType: SHA_512
+              algValue: 1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96
+          url: https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe
+          signatureUrl: https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc
+
 
     #
     # TEA Collection and related objects
@@ -487,6 +591,15 @@ components:
         type:
           description: Type of artifact
           "$ref": "#/components/schemas/artifact-type"
+        componentFormats:
+          type: array
+          description: |
+            List of component formats that this artifact applies to.
+            If absent, the artifact applies to all components.
+          items:
+            type: string
+            description: |
+              The `id` of the component format that this artifact applies to.
         formats:
           type: array
           description: |
@@ -531,17 +644,17 @@ components:
           type: array
           description: List of checksums for the artifact
           items:
-            "$ref": "#/components/schemas/artifact-checksum"
-    artifact-checksum:
+            "$ref": "#/components/schemas/checksum"
+    checksum:
       type: object
       properties:
         algType:
           description: Checksum algorithm
-          "$ref": "#/components/schemas/artifact-checksum-type"
+          "$ref": "#/components/schemas/checksum-type"
         algValue:
           type: string
           description: Checksum value
-    artifact-checksum-type:
+    checksum-type:
       type: string
       description: Checksum algorithm
       enum:

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -17,6 +17,17 @@ A TEA Component Release object has the following parts:
 - __identifiers__: List of identifiers for the component
   - __idType__: Type of identifier, e.g. `tei`, `purl`, `cpe`
   - __idValue__: Identifier value
+- __formats__: List of different formats of this component release
+  - __id__: A short name for this release format
+  - __description__: A free text describing the component variant
+  - __identifiers__: List identifiers for this release format
+    - __idType__: Type of identifier, e.g. `tei`, `purl`, `cpe`
+    - __idValue__: Identifier value
+  - __url__: Direct download URL for the release format
+  - __signatureUrl__: Direct download URL for an external signature of the release format
+  - __checksums__: List of checksums for the release format
+    - __algType__: Checksum algorithm
+    - __algValue__: Checksum value
 
 ### Examples
 
@@ -129,6 +140,9 @@ The TEA Artifact object has the following parts:
 - __name__: Artifact name.
 - __type__: Type of artifact.
   See [TEA Artifact types](#tea-artifact-types) for a list.
+- __componentFormats__: 
+  List of `id`s of component formats that this artifact applies to.
+  If absent, the artifact applies to all components.
 - __formats__: List of objects with the same content, but in different formats.
   The order of the list has no significance.
   - __mime_type__: The MIME type of the document


### PR DESCRIPTION
Similarly to TEA Artifacts, each TEA Component Release can include multiple deliverables representing the same software in different file formats or for different architectures.

This PR introduces:

- A `formats` property to the TEA Component Release, which includes:
  - a description,
  - a set of identifiers,
  - for software components: a set of checksums for the binary distribution file, a download URL, and a URL for an external signature.
- A `componentFormats` property to TEA Artifact, allowing restriction of which component formats a document applies to.

These changes enable more precise mapping between security artifacts and the distribution formats of components.