### PR TITLE
Add concept of Product Release with its own Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ tags in the repository as well as in the slack channel.
 ## Introduction
 
 This specification defines a standard, format agnostic, API for the exchange of
-product related artifacts, like BOMs, between systems. The work includes:
+product related artefacts, like BOMs, between systems. The work includes:
 
 - [Discovery of servers](/discovery/readme.md): Describes discovery using the Transparency Exchange Identifier (TEI)
-- Retrieval of artifacts
-- Publication of artifacts
+- Retrieval of artefacts
+- Publication of artefacts
 - Authentication and authorization
 - Querying
 
 System and tooling implementors are encouraged to adopt this API standard for
-sending/receiving transparency artifacts between systems. 
+sending/receiving transparency artefacts between systems. 
 This will enable more widespread
 "out of the box" integration support in the BOM ecosystem.
 
@@ -58,24 +58,24 @@ The working group has produced a list of use cases and requirements for the prot
 - [TEA Product](tea-product/tea-product.md): An optional higher-level object that groups a set of Product Releases for a product line or family. Products can be discovered and browsed; releases are accessed via `/product/{uuid}/releases`.
 - [TEA Component](tea-component/tea-component.md): Represents a component lineage. A Component is a collection of Component Releases (accessible via `/component/{uuid}/releases`).
 - [TEA Release](/tea-component/tea-release.md: A Component Release object. Each Component Release may have its own TEA Collection.
-- [TEA Collection](tea-collection/tea-collection.md): A versioned list of artifacts for a specific Release (Component Release) or Product Release. Collections are versioned to indicate changes, e.g., an updated VEX or corrected SBOM.
-- [TEA Artifacts](tea-artifact/tea-artifact.md): Files associated with a Collection. A single Artifact can appear in multiple Collections.
+- [TEA Collection](tea-collection/tea-collection.md): A versioned list of artefacts for a specific Release (Component Release) or Product Release. Collections are versioned to indicate changes, e.g., an updated VEX or corrected SBOM.
+- [TEA Artefacts](tea-artifact/tea-artifact.md): Files associated with a Collection. A single Artefact can appear in multiple Collections.
 
-## artifacts available of the API
+## Artefacts available of the API
 
-The Transparency Exchange API (TEA) supports publication and retrieval of a set of transparency exchange artifacts. The API itself should not be restricting the types of the artifacts. A few examples:
+The Transparency Exchange API (TEA) supports publication and retrieval of a set of transparency exchange artefacts. The API itself should not be restricting the types of the artefacts. A few examples:
 
 ### xBOM
 
-Bill of materials for any type of component and service are supported. This includes, but is not limited to, SBOM, HBOM, AI/ML-BOM, SaaSBOM, and CBOM. The API provides a BOM format agnostic way of publishing, searching, and retrieval of xBOM artifacts. 
+Bill of materials for any type of component and service are supported. This includes, but is not limited to, SBOM, HBOM, AI/ML-BOM, SaaSBOM, and CBOM. The API provides a BOM format agnostic way of publishing, searching, and retrieval of xBOM artefacts. 
 
 ### CDXA
 
-Standards and requirements along with attestations to those standards and requirements are captured and supported by CycloneDX Attestations (CDXA). Much like xBOM, these are supply chain artifacts that are captured allowing for consistent publishing, searching, and retrieval.
+Standards and requirements along with attestations to those standards and requirements are captured and supported by CycloneDX Attestations (CDXA). Much like xBOM, these are supply chain artefacts that are captured allowing for consistent publishing, searching, and retrieval.
 
 ### VDR/VEX
 
-Vulnerability Disclosure Reports (VDR) and Vulnerability Exploitability eXchange (VEX) are supported artifact types. Like the xBOM element, the VDR/VEX support is format agnostic. However, CSAF has its own distribution requirements that may not be compatible with APIs. Therefore, the initial focus will be on CycloneDX (VDR and VEX) and OpenVEX.
+Vulnerability Disclosure Reports (VDR) and Vulnerability Exploitability eXchange (VEX) are supported artefact types. Like the xBOM element, the VDR/VEX support is format agnostic. However, CSAF has its own distribution requirements that may not be compatible with APIs. Therefore, the initial focus will be on CycloneDX (VDR and VEX) and OpenVEX.
 
 ### CLE
 
@@ -105,7 +105,7 @@ Contributors are listed in the [Contributors](contributors.md) file.
 - API: Application programming interface
 - Authorization (authz):
 - Authentication (authn):
-- Collection: A set of artifacts representing a version of a product
+- Collection: A set of artefacts representing a version of a product
 - Product: An item sold or delivered under one name
 - Product variant: A variant of a product
 - Version:

--- a/README.md
+++ b/README.md
@@ -54,15 +54,12 @@ The working group has produced a list of use cases and requirements for the prot
 
 ## Data model
 
-- [TEA Product](tea-product/tea-product): This is the starting point. A "product" is something for sale or distributed as an Open Source project. The [Transparency Exchange Identifier, TEI](/discovery/readme.md) points to a single product. A product can have multiple TEIs.
-- [TEA Component](tea-component/tea-component.md): A Component is a versioned part of the product. In many cases, the product has a single component,
-  and in other cases a product consists of multiple components.
-  - TEA Components has a list of "releases" for each component.
-- [TEA Collection](tea-collection/tea-collection.md): The collection is a list of artifacts for a specific release. The collection can be
-  dynamic or static, depending on the implemenation. TEA collections are versioned to indicate a change for a specific release,
-  like an update of a VEX file or a correction of an SBOM.
-- [TEA Artifacts](tea-artifact/tea-artifact.md): The artifact is a file associated with the collection. One artifact can be part of many collections,
-  for multiple components.
+- [TEA Product Release](tea-product/tea-product-release.md): The primary entry point. The [Transparency Exchange Identifier, TEI](/discovery/readme.md) resolves to a specific Product Release. A Product Release may optionally belong to a [TEA Product](tea-product/tea-product.md).
+- [TEA Product](tea-product/tea-product.md): An optional higher-level object that groups a set of Product Releases for a product line or family. Products can be discovered and browsed; releases are accessed via `/product/{uuid}/releases`.
+- [TEA Component](tea-component/tea-component.md): Represents a component lineage. A Component is a collection of Component Releases (accessible via `/component/{uuid}/releases`).
+- [TEA Release](/tea-component/tea-release.md: A Component Release object. Each Component Release may have its own TEA Collection.
+- [TEA Collection](tea-collection/tea-collection.md): A versioned list of artifacts for a specific Release (Component Release) or Product Release. Collections are versioned to indicate changes, e.g., an updated VEX or corrected SBOM.
+- [TEA Artifacts](tea-artifact/tea-artifact.md): Files associated with a Collection. A single Artifact can appear in multiple Collections.
 
 ## artifacts available of the API
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -27,8 +27,7 @@ paths:
           required: true
           description: UUID of the TEA product in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Product found and returned
@@ -52,8 +51,7 @@ paths:
           required: true
           description: UUID of TEA Product in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested Releases of TEA Product found and returned
@@ -79,8 +77,7 @@ paths:
           required: true
           description: UUID of TEA Product Release in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Product Release found and returned
@@ -105,7 +102,7 @@ paths:
         - $ref: "#/components/parameters/id-value"
       responses:
         '200':
-          $ref: "#/components/responses/paginated-productRelease"
+          $ref: "#/components/responses/paginated-product-release"
         '400':
           $ref: "#/components/responses/400-invalid-request"
       tags:
@@ -137,8 +134,7 @@ paths:
           required: true
           description: UUID of TEA Component in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Component found and returned
@@ -162,8 +158,7 @@ paths:
           required: true
           description: UUID of TEA Component in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested Releases of TEA Component found and returned
@@ -189,8 +184,7 @@ paths:
           required: true
           description: UUID of TEA Release in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Collection found and returned
@@ -214,8 +208,7 @@ paths:
           required: true
           description: UUID of TEA Product Release in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Collection found and returned
@@ -239,8 +232,7 @@ paths:
           required: true
           description: UUID of TEA Release in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Collection found and returned
@@ -266,8 +258,7 @@ paths:
           required: true
           description: UUID of TEA Product Release in the TEA server
           schema:
-            type: string
-            format: uuid
+            "$ref": "#/components/schemas/uuid"
       responses:
         '200':
           description: Requested TEA Collection found and returned
@@ -291,7 +282,7 @@ paths:
         - name: uuid
           in: path
           required: true
-          description: UUID of TEA Collection in the TEA server
+          description: UUID of TEA Release in the TEA server
           schema:
             "$ref": "#/components/schemas/uuid"
         - name: collectionVersion
@@ -528,7 +519,7 @@ components:
     # Reference to a component, in some cases directly to a specific release
     # 
     # The release reference (release UUID) is only used in cases where a product
-    # name incldues a version and this version of the product always include
+    # name includes a version and this version of the product always includes
     # the same releases of the component.
     component-ref:
       type: object
@@ -653,10 +644,10 @@ components:
               name: Build SBOM
               type: BOM
               formats:
-                - mime_type: application/vnd.cyclonedx+xml
+                - mimeType: application/vnd.cyclonedx+xml
                   description: CycloneDX SBOM (XML)
                   url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml
-                  signature_url: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc
+                  signatureUrl: https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc
                   checksums:
                     - algType: MD5
                       algValue: 2e1a525afc81b0a8ecff114b8b743de9
@@ -664,9 +655,9 @@ components:
                       algValue: 5a7d4caef63c5c5ccdf07c39337323529eb5a770
             - uuid: dfa35519-9734-4259-bba1-3e825cf4be06
               name: Vulnerability Disclosure Report
-              type: vulnerability-assertion
+              type: VULNERABILITIES
               formats:
-                - mime_type: application/vnd.cyclonedx+xml
+                - mimeType: application/vnd.cyclonedx+xml
                   description: CycloneDX VDR (XML)
                   url: https://logging.apache.org/cyclonedx/vdr.xml
                   checksums:
@@ -742,7 +733,7 @@ components:
       type: object
       description: A security-related document in a specific format
       properties:
-        mime_type:
+        mimeType:
           type: string
           description: The MIME type of the document
         description:
@@ -842,7 +833,7 @@ components:
                     type: array
                     items:
                       "$ref": "#/components/schemas/product"
-    paginated-productRelease:
+    paginated-product-release:
       description: A paginated response containing TEA Product Releases
       content:
         application/json:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -19,7 +19,7 @@ servers:
 paths:
   /product/{uuid}:
     get:
-      description: Returns the corresponding TEA components for a given TEA product UUID.
+      description: Get a TEA Product by UUID
       operationId: getTeaProductByUuid
       parameters:
         - name: uuid
@@ -42,6 +42,74 @@ paths:
           $ref: "#/components/responses/404-object-by-id-not-found"
       tags:
         - TEA Product
+  /product/{uuid}/releases:
+    get:
+      description: Get releases of the product
+      operationId: getReleasesByProductId
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: UUID of TEA Product in the TEA server
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Requested Releases of TEA Product found and returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/productRelease"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+        '404':
+          $ref: "#/components/responses/404-object-by-id-not-found"
+      tags:
+        - TEA Product Release
+  /productRelease/{uuid}:
+    get:
+      description: Get a TEA Product Release
+      operationId: getTeaProductReleaseByUuid
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: UUID of TEA Product Release in the TEA server
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Requested TEA Product Release found and returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/productRelease"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+        '404':
+          $ref: "#/components/responses/404-object-by-id-not-found"
+      tags:
+        - TEA Product Release
+  /productReleases:
+    get:
+      description: Returns a list of TEA product releases. Note that multiple product releases may match.
+      operationId: getTeaProductReleaseByIdentifier
+      parameters:
+        - $ref: "#/components/parameters/page-offset"
+        - $ref: "#/components/parameters/page-size"
+        - $ref: "#/components/parameters/id-type"
+        - $ref: "#/components/parameters/id-value"
+      responses:
+        '200':
+          $ref: "#/components/responses/paginated-productRelease"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+      tags:
+        - TEA Product Release
   /products:
     get:
       description: Returns a list of TEA products. Note that multiple products may
@@ -136,6 +204,31 @@ paths:
           $ref: "#/components/responses/404-object-by-id-not-found"
       tags:
         - TEA Release
+  /productRelease/{uuid}/collection/latest:
+    get:
+      description: Get the latest TEA Collection belonging to the TEA Product Release
+      operationId: getLatestCollectionForProductRelease
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: UUID of TEA Product Release in the TEA server
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Requested TEA Collection found and returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/collection"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+        '404':
+          $ref: "#/components/responses/404-object-by-id-not-found"
+      tags:
+        - TEA Product Release
   /release/{uuid}/collections:
     get:
       description: Get the TEA Collections belonging to the TEA Release
@@ -163,6 +256,63 @@ paths:
           $ref: "#/components/responses/404-object-by-id-not-found"
       tags:
         - TEA Release
+  /productRelease/{uuid}/collections:
+    get:
+      description: Get the TEA Collections belonging to the TEA Product Release
+      operationId: getCollectionsByProductReleaseId
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: UUID of TEA Product Release in the TEA server
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Requested TEA Collection found and returned
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/collection"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+        '404':
+          $ref: "#/components/responses/404-object-by-id-not-found"
+      tags:
+        - TEA Product Release
+  /productRelease/{uuid}/collection/{collectionVersion}:
+    get:
+      description: Get a specific Collection (by version) for a TEA Product Release by its UUID
+      operationId: getCollectionForProductRelease
+      parameters:
+        - name: uuid
+          in: path
+          required: true
+          description: UUID of TEA Collection in the TEA server
+          schema:
+            "$ref": "#/components/schemas/uuid"
+        - name: collectionVersion
+          in: path
+          required: true
+          description: Version of TEA Collection
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Requested TEA Collection Version found and returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/collection"
+        '400':
+          $ref: "#/components/responses/400-invalid-request"
+        '404':
+          $ref: "#/components/responses/404-object-by-id-not-found"
+      tags:
+        - TEA Product Release
   /release/{uuid}/collection/{collectionVersion}:
     get:
       description: Get a specific Collection (by version) for a TEA Release by its UUID
@@ -270,20 +420,10 @@ components:
             List of identifiers for the product, like TEI, CPE, PURL or other identifiers
           items:
             "$ref": "#/components/schemas/identifier"
-        components:
-          type: array
-          description: |
-            List of TEA component-refs for the product. The component-ref by default just 
-            includes the UUID of the component, but in some cases also include a reference
-            to the UUID of a specific release.
-          items:
-            description: Unique identifier of the TEA component-ref
-            "$ref": "#/components/schemas/uuid"
       required:
         - uuid
         - name
         - identifiers
-        - components
       examples:
         - uuid: 09e8c73b-ac45-4475-acac-33e6a7314e6d
           name: Apache Log4j 2
@@ -292,10 +432,61 @@ components:
               idValue: cpe:2.3:a:apache:log4j
             - idType: PURL
               idValue: pkg:maven/org.apache.logging.log4j/log4j-api
+
+    #
+    # TEA Product Release
+    #
+    productRelease:
+      type: object
+      description: A specific release of a TEA product
+      properties:
+        uuid:
+          description: A unique identifier for the TEA Product Release
+          "$ref": "#/components/schemas/uuid"
+        version:
+          description: Version number of the product release
+          type: string
+          example: 2.24.3
+        createdDate:
+          description: Timestamp when this Product Release was created in TEA (for sorting purposes)
+          "$ref": "#/components/schemas/date-time"
+        releaseDate:
+          description: Timestamp of the product release
+          "$ref": "#/components/schemas/date-time"
+        preRelease:
+          type: boolean
+          description: |
+            A flag indicating pre-release (or beta) status.
+            May be disabled after the creation of the release object, but can't be enabled after creation of an object.
+        identifiers:
+          type: array
+          description: List of identifiers for the product release
+          items:
+            "$ref": "#/components/schemas/identifier"
+        components:
+          type: array
+          description: |
+            List of component references that compose this product release. A component reference can optionally include
+            the UUID of a specific component release to pin the exact version.
+          items:
+            "$ref": "#/components/schemas/component-ref"
+      required:
+        - uuid
+        - version
+        - createdDate
+        - components
+      examples:
+        - uuid: 123e4567-e89b-12d3-a456-426614174000
+          version: "2.24.3"
+          createdDate: 2025-04-01T15:43:00Z
+          releaseDate: 2025-04-01T15:43:00Z
+          identifiers:
+            - idType: TEI
+              idValue: tei:vendor:product@2.24.3
           components:
-            - 3910e0fd-aff4-48d6-b75f-8bf6b84687f0
-            - b844c9bd-55d6-478c-af59-954a932b6ad3
-            - d6d3f754-d4f4-4672-b096-b994b064ca2d
+            - uuid: 3910e0fd-aff4-48d6-b75f-8bf6b84687f0
+            - uuid: b844c9bd-55d6-478c-af59-954a932b6ad3
+              release: da89e38e-95e7-44ca-aa7d-f3b6b34c7fab
 
     #
     # TEA Component and related objects
@@ -319,7 +510,6 @@ components:
         - uuid
         - name
         - identifiers
-        - versions
       examples:
         - uuid: 3910e0fd-aff4-48d6-b75f-8bf6b84687f0
           name: Apache Log4j API
@@ -348,13 +538,11 @@ components:
           description: A unique identifier for the TEA component
           "$ref": "#/components/schemas/uuid"
         release:
-          type: string
           description: |
             Optional UUID of a specific release included in the product in the case where the product
             always include a specific release of a component. The product name should include a version
             identifier in this case.
-          items:
-            "$ref": "#/components/schemas/uuid"
+          "$ref": "#/components/schemas/uuid"
       required:
         - uuid
 
@@ -430,7 +618,7 @@ components:
         uuid:
           description: |
             UUID of the TEA Collection object.
-            Note that this is equal to the UUID of the associated TEA Component Release object.
+            This matches the UUID of the associated TEA Component Release or TEA Product Release object.
             When updating a collection, only the `version` is changed.
           "$ref": "#/components/schemas/uuid"
         version:
@@ -441,6 +629,9 @@ components:
         date:
           description: The date when the TEA Collection version was created.
           "$ref": "#/components/schemas/date-time"
+        belongsTo:
+          description: Indicates whether this collection belongs to a Component Release or a Product Release
+          "$ref": "#/components/schemas/collection-belongs-to-type"
         updateReason:
           description: Reason for the update/release of the TEA Collection object.
           "$ref": "#/components/schemas/collection-update-reason"
@@ -501,6 +692,13 @@ components:
         - ARTIFACT_UPDATED
         - ARTIFACT_ADDED
         - ARTIFACT_REMOVED
+
+    collection-belongs-to-type:
+      type: string
+      description: Indicates whether a collection belongs to a component release or a product release
+      enum:
+        - RELEASE
+        - PRODUCT_RELEASE
 
     #
     # TEA Artifact and related objects
@@ -644,6 +842,19 @@ components:
                     type: array
                     items:
                       "$ref": "#/components/schemas/product"
+    paginated-productRelease:
+      description: A paginated response containing TEA Product Releases
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/pagination-details"
+              - type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      "$ref": "#/components/schemas/productRelease"
   parameters:
     # Pagination
     page-offset:
@@ -715,6 +926,7 @@ security:
   - basicAuth: []
 tags:
   - name: TEA Product
+  - name: TEA Product Release
   - name: TEA Component
   - name: TEA Release
   - name: TEA Artifact

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -434,6 +434,9 @@ components:
         uuid:
           description: A unique identifier for the TEA Product Release
           "$ref": "#/components/schemas/uuid"
+        product:
+          description: UUID of the TEA Product this release belongs to
+          "$ref": "#/components/schemas/uuid"
         version:
           description: Version number of the product release
           type: string
@@ -547,6 +550,9 @@ components:
       properties:
         uuid:
           description: A unique identifier for the TEA Component Release
+          "$ref": "#/components/schemas/uuid"
+        component:
+          description: UUID of the TEA Component this release belongs to
           "$ref": "#/components/schemas/uuid"
         version:
           description: Version number

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -1,74 +1,275 @@
-# TEA release and collections
+# TEA Releases and Collections
 
-## The TEA release object (TRO)
+## The TEA Component Release object (TRO)
 
-The TEA Component Release object corresponds to a specific variant
-(version) of a component with a release identifier (string),
-release timestamp and a lifecycle enumeration for the release.
-The UUID of the TEA Component Release object matches the UUID of the associated TEA Collection objects (TCO).
+A TEA Component Release object represents a specific version of a component,
+identified by a unique version number and associated metadata.
+Each release may include multiple distributions,
+which capture variations such as architecture, packaging, or localization.
 
-A TEA Component Release object has the following parts:
+- For software components,
+  each distribution typically corresponds to a different digital file delivered to users
+  (e.g., by platform or packaging type).
+- For hardware components, distributions may reflect differences in packaging, language, or other physical attributes.
 
-- __uuid__: A unique identifier for the TEA Component Release
-- __version__: Version number
-- __releaseDate__: Timestamp of the release (for sorting purposes)
-- __preRelease__: A flag indicating pre-release (or beta) status.
-  May be disabled after the creation of the release object, but can't be enabled after creation of an object.
-- __identifiers__: List of identifiers for the component
-  - __idType__: Type of identifier, e.g. `TEI`, `PURL`, `CPE`
-  - __idValue__: Identifier value
+Each distribution is assigned a unique `distributionType`, defined by the producer,
+which is used to associate relevant TEA Artifacts with that distribution.
+Since TEA Artifacts can be associated with multiple release objects,
+the taxonomy for `distributionType` values should be defined on a TEA service level
+and consistently applied to all TEA Artifacts published by that producer.
+This ensures global uniqueness and reliable association across releases.
+
+The `uuid` of the TEA Component Release object is identical to the `uuid` of its associated
+[TEA Collection object (TCO)](#the-tea-collection-object-tco).
+
+### Structure
+
+A TEA Component Release object contains the following fields:
+
+- __uuid__: Unique identifier for the TEA Component Release.
+- __version__: Version number of the release.
+- __createdDate__: Timestamp when the release object was created.
+- __releaseDate__: Timestamp of the actual release.
+- __preRelease__: Boolean flag indicating if this is a pre-release (e.g., beta).
+  This flag can be disabled after creation, but not enabled.
+- __identifiers__: List of identifiers for the component.
+  - __idType__: Type of identifier (e.g., `TEI`, `PURL`, `CPE`).
+  - __idValue__: Value of the identifier.
+- __distributions__: List of release distributions, each with:
+  - __distributionType__: Unique identifier for the distribution type.
+  - __description__: Free-text description of the distribution.
+  - __identifiers__: List of identifiers specific to this distribution.
+    - __idType__: Type of identifier (e.g., `TEI`, `PURL`, `CPE`).
+    - __idValue__: Value of the identifier.
+  - __url__: Direct download URL for the distribution.
+  - __signatureUrl__: Direct download URL for the distribution's external signature.
+  - __checksums__: List of checksums for the distribution.
+    - __algType__: Checksum algorithm used.
+    - __algValue__: Checksum value.
 
 ### Examples
 
-A TEA Component Release object of the binary distribution of Apache Tomcat 11.0.6 will look like:
+#### Single distribution
+
+This example shows a TEA Component Release for Apache Log4j Core, which is distributed as a single JAR file.
+Even though there is only one distribution,
+the `distributions` attribute is included to enable searching for the release by the SHA-256 checksum of the JAR.
+This structure also allows for future extensibility if additional distributions are introduced.
+
+<details>
+  <summary>Example of simple release</summary>
+
+```json
+{
+  "uuid": "b1e2c3d4-5678-49ab-9cde-123456789abc",
+  "version": "2.24.3",
+  "createdDate": "2024-12-10T10:51:00Z",
+  "releaseDate": "2024-12-13T12:52:29Z",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3"
+    }
+  ],
+  "distributions": [
+    {
+      "distributionType": "jar",
+      "description": "Binary distribution",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3?type=jar"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA-256",
+          "algValue": "b1e2c3d4f5a67890b1e2c3d4f5a67890b1e2c3d4f5a67890b1e2c3d4f5a67890"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar.asc"
+    }
+  ]
+}
+```
+</details>
+
+#### Multiple distributions
+
+This is an example of a TEA Component Release for Apache Tomcat 11.0.7 binary distributions.
+The example defines four distinct `distributionType`s,
+which is essential not only for associating the correct SBOMs with each distribution,
+but also for accurately tracking and reporting vulnerabilities that may affect only specific distributions.
+For instance:
+
+- The `zip` and `tar.gz` distributions contain only Java JARs.
+- The `windows-x64.zip` distribution additionally includes the
+  [Apache Procrun](https://commons.apache.org/proper/commons-daemon/procrun.html) binary,
+  which is specific to Windows and may introduce unique vulnerabilities.
+- The `windows-x64.exe` distribution contains the same data as `windows-x64.zip`,
+  but is packaged as a self-extracting installer
+  created by the [Nullsoft Scriptable Install System](https://nsis.sourceforge.io/Main_Page).
+
+By defining separate `distributionType`s,
+it becomes possible to precisely associate artifacts and vulnerability disclosures with the affected distributions,
+ensuring accurate risk assessment and remediation.
+
+<details>
+  <summary>Example of four different binary distributions in the same release</summary>
 
 ```json
 {
   "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
-  "version": "11.0.6",
-  "releaseDate": "2025-04-01T15:43:00Z",
+  "version": "11.0.7",
+  "createdDate": "2025-05-07T18:08:00Z",
+  "releaseDate": "2025-05-12T18:08:00Z",
   "identifiers": [
     {
       "idType": "PURL",
-      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6"
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7"
+    }
+  ],
+  "distributions": [
+    {
+      "distributionType": "zip",
+      "description": "Core binary distribution, zip archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7?type=zip"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip.asc"
+    },
+    {
+      "distributionType": "tar.gz",
+      "description": "Core binary distribution, tar.gz archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7?type=tar.gz"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.tar.gz",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.tar.gz.asc"
+    },
+    {
+      "distributionType": "windows-x64.zip",
+      "description": "Core binary distribution, Windows x64 zip archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7?classifier=windows-x64&type=zip"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7-windows-x64.zip",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip.asc"
+    },
+    {
+      "distributionType": "windows-x64.exe",
+      "description": "Core binary distribution, Windows Service Installer (MSI)",
+      "checksums": [
+        {
+          "algType": "SHA_512",
+          "algValue": "1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96"
+        }
+      ],
+      "url": "https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe",
+      "signatureUrl": "https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc"
     }
   ]
 }
 ```
+</details>
 
-Different versions of Apache Tomcat should have separate TEA Component Release objects:
+#### Pre-release flag usage
 
-```json
-{
-  "uuid": "da89e38e-95e7-44ca-aa7d-f3b6b34c7fab",
-  "version": "10.1.4",
-  "releaseDate": "2025-04-01T18:20:00Z",
-  "identifiers": [
-    {
-      "idType": "PURL",
-      "idValue": "pkg:maven/org.apache.tomcat/tomcat@10.1.4"
-    }
-  ]
-}
-```
+The `preRelease` flag is used to indicate that a release is not production ready,
+regardless of the version naming scheme.
+This helps consumers identify non-production releases without relying on conventions like `-beta`,
+`-rc`, or `-M` in the version string.
 
-The pre-release flag is used to mark versions not production ready
-and does not require users to know the version naming scheme adopted by the project.
+There are two main scenarios for using the `preRelease` flag:
 
-```json
-{
-  "uuid": "95f481df-f760-47f4-b2f2-f8b76d858450",
-  "version": "11.0.0-M26",
-  "releaseDate": "2024-09-13T17:49:00Z",
-  "preRelease": true,
-  "identifiers": [
-    {
-      "idType": "PURL",
-      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
-    }
-  ]
-}
-```
+- **Pending release:** The distribution is still undergoing quality assurance or review and is not yet officially released.
+  These typically lack a `releaseDate` attribute.
+  Once the release is approved, the `preRelease` flag is set to `false` and the `releaseDate` is added.
+- **Permanent pre-release:** The distribution is intentionally marked as a pre-release
+ (e.g., beta, milestone, or release candidate) and will never be considered production ready,
+  even after all checks are complete.
+  These may have a `releaseDate`, but `preRelease` remains `true`.
+
+<details>
+  <summary>Examples of non-production ready distributions</summary>
+
+- **Pending release (no `releaseDate`):**
+  ```json
+  {
+    "uuid": "e2a1c7b4-3f2d-4e8a-9c1a-7b2e4d5f6a8b",
+    "version": "11.0.0",
+    "createdDate": "2025-09-01T00:00:00Z",
+    "preRelease": true,
+    "identifiers": [
+      {
+        "idType": "PURL",
+        "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0?repository_url=https:%2F%2Frepository.apache.org%2Fcontent%2Fgroups%2Fstaging%2F"
+      }
+    ]
+  }
+  ```
+- **Transition to production-ready (`preRelease` flag turned off, `releaseDate` added)**:
+  ```json
+  {
+    "uuid": "e2a1c7b4-3f2d-4e8a-9c1a-7b2e4d5f6a8b",
+    "version": "11.0.0",
+    "createdDate": "2025-09-01T00:00:00Z",
+    "releaseDate": "2025-09-10T12:00:00Z",
+    "preRelease": false,
+    "identifiers": [
+      {
+        "idType": "PURL",
+        "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0"
+      }
+    ]
+  }
+  ```
+- **Beta version (has `releaseDate`, but not production ready)**:
+  ```json
+  {
+    "uuid": "95f481df-f760-47f4-b2f2-f8b76d858450",
+    "version": "11.0.0-M26",
+    "createdDate": "2024-09-13T17:49:00Z",
+    "releaseDate": "2024-09-16T17:49:00Z",
+    "preRelease": true,
+    "identifiers": [
+      {
+        "idType": "PURL",
+        "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
+      }
+    ]
+  }
+  ```
+</details>
 
 ## The TEA Collection object (TCO)
 
@@ -105,42 +306,69 @@ to implement this:
 
 ### Collection object
 
-The TEA Collection object has the following parts:
+  The TEA Collection object has the following parts:
 
-- Preamble
+  - Preamble
   - __uuid__: UUID of the TEA Collection object.
     Note that this is equal to the UUID of the associated TEA Component Release object.
     When updating a collection, only the `version` is changed.
   - __version__: TEA Collection version, incremented each time its content changes.
     Versions start with 1.
-  - __releaseDate__: TEA Collection version release date.
+  - __date__: TEA Collection version release date.
+  - __belongsTo__: Scope of the collection; enum values `RELEASE` or `PRODUCT_RELEASE`.
   - __updateReason__: Reason for the update/release of the TEA Collection object.
     - __type__: Type of update reason.
       See [reasons for TEA Collection update](#the-reason-for-tco-update-enum) below.
     - __comment__: Free text description.
-- __artifacts__: List of TEA artifact objects.
-  See [below](#artifact-object).
+  -
+  - __artifacts__: List of TEA artifact objects.
+    See [below](#artifact-object).
 
-### Artifact object
+## The TEA Artifact object
 
-The TEA Artifact object has the following parts:
+A TEA Artifact object represents a security-related document or file linked to a component release,
+such as an SBOM, VEX, attestation, or license.
+Artifacts are strictly **immutable**: if the underlying document changes, a new TEA Artifact object must be created.
+URLs referenced in this object must always resolve to the same resource to ensure that published checksums remain valid and verifiable.
 
-- __uuid__: UUID of the TEA Artifact object.
-- __name__: Artifact name.
-- __type__: Type of artifact.
-  See [TEA Artifact types](#tea-artifact-types) for a list.
-  - __formats__: List of objects with the same content, but in different formats.
-  The order of the list has no significance.
-  - __mimeType__: The MIME type of the document
-  - __description__: A free text describing the artifact
-  - __url__: Direct download URL for the artifact
-  - __signatureUrl__: Direct download URL for an external signature of the artifact
-  - __checksums__: List of checksums for the artifact
-    - __algType__: Checksum algorithm
-      See [CycloneDX checksum algorithms](https://cyclonedx.org/docs/1.6/json/#components_items_hashes_items_alg) for a list of supported values.
-    - __algValue__: Checksum value
+TEA Artifacts can be reused across multiple TEA Collections,
+allowing the same document to be referenced by different component releases or even different components.
+This promotes consistency and reduces duplication.
 
-### The reason for TCO update enum
+Optionally, each artifact can specify the `distributionType` identifiers of the distributions it applies to.
+If this field is absent, the artifact is considered applicable to all distributions of the release.
+
+### Structure
+
+A TEA Artifact object contains the following fields:
+
+- __uuid__: The UUID of the TEA Artifact object. This uniquely identifies the artifact.
+- __name__: A human-readable name for the artifact.
+- __type__: The type of artifact. See [TEA Artifact types](#tea-artifact-types) for allowed values (e.g., `BOM`, `VULNERABILITIES`, `LICENSE`).
+- __componentDistributions__ (optional):  
+  An array of `distributionType` identifiers indicating which distributions this artifact applies to.
+  If omitted, the artifact applies to all distributions.
+- __formats__:  
+  An array of objects, each representing the same artifact content in a different format.
+  The order of the list is not significant.
+  Each format object includes:
+  - __mimeType__: The MIME type of the document (e.g., `application/vnd.cyclonedx+xml`).
+  - __description__: A free-text description of the artifact format.
+  - __url__: A direct download URL for the artifact. This must point to an immutable resource.
+  - __signatureUrl__ (optional): A direct download URL for a detached digital signature of the artifact, if available.
+  - __checksums__:  
+    An array of checksum objects for the artifact, each containing:
+    - __algType__: The checksum algorithm used (e.g., `SHA_256`, `SHA3_512`).
+    - __algValue__: The checksum value as a string.
+
+### Notes
+
+- The `formats` array allows the same artifact to be provided in multiple encodings or serializations (e.g., JSON, XML).
+- The `checksums` field provides integrity verification for each artifact format.
+- The `signatureUrl` enables consumers to verify the authenticity of the artifact using detached signatures.
+- Artifacts should be published to stable, versioned URLs to ensure immutability and traceability.
+
+## The reason for TCO update enum
 
 | ENUM             | Description                            |
 |------------------|----------------------------------------|
@@ -153,7 +381,7 @@ The TEA Artifact object has the following parts:
 Updates of VEX (CSAF) files may be handled in a different way by a TEA client,
 producing different alerts than other changes of a collection.
 
-### TEA Artifact types
+## TEA Artifact types
 
 | ENUM            | Description                                                                         |
 |-----------------|-------------------------------------------------------------------------------------|
@@ -175,7 +403,7 @@ producing different alerts than other changes of a collection.
 {
   "uuid": "4c72fe22-9d83-4c2f-8eba-d6db484f32c8",
   "version": 1,
-  "releaseDate": "2024-12-13T00:00:00Z",
+  "date": "2024-12-13T00:00:00Z",
   "updateReason": {
     "type": "ARTIFACT_UPDATED",
     "comment": "VDR file updated"

--- a/tea-collection/tea-collection.md
+++ b/tea-collection/tea-collection.md
@@ -15,7 +15,7 @@ A TEA Component Release object has the following parts:
 - __preRelease__: A flag indicating pre-release (or beta) status.
   May be disabled after the creation of the release object, but can't be enabled after creation of an object.
 - __identifiers__: List of identifiers for the component
-  - __idType__: Type of identifier, e.g. `tei`, `purl`, `cpe`
+  - __idType__: Type of identifier, e.g. `TEI`, `PURL`, `CPE`
   - __idValue__: Identifier value
 
 ### Examples
@@ -29,7 +29,7 @@ A TEA Component Release object of the binary distribution of Apache Tomcat 11.0.
   "releaseDate": "2025-04-01T15:43:00Z",
   "identifiers": [
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6"
     }
   ]
@@ -45,7 +45,7 @@ Different versions of Apache Tomcat should have separate TEA Component Release o
   "releaseDate": "2025-04-01T18:20:00Z",
   "identifiers": [
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.tomcat/tomcat@10.1.4"
     }
   ]
@@ -63,7 +63,7 @@ and does not require users to know the version naming scheme adopted by the proj
   "preRelease": true,
   "identifiers": [
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
     }
   ]
@@ -129,12 +129,12 @@ The TEA Artifact object has the following parts:
 - __name__: Artifact name.
 - __type__: Type of artifact.
   See [TEA Artifact types](#tea-artifact-types) for a list.
-- __formats__: List of objects with the same content, but in different formats.
+  - __formats__: List of objects with the same content, but in different formats.
   The order of the list has no significance.
-  - __mime_type__: The MIME type of the document
+  - __mimeType__: The MIME type of the document
   - __description__: A free text describing the artifact
   - __url__: Direct download URL for the artifact
-  - __signature_url__: Direct download URL for an external signature of the artifact
+  - __signatureUrl__: Direct download URL for an external signature of the artifact
   - __checksums__: List of checksums for the artifact
     - __algType__: Checksum algorithm
       See [CycloneDX checksum algorithms](https://cyclonedx.org/docs/1.6/json/#components_items_hashes_items_alg) for a list of supported values.
@@ -184,13 +184,13 @@ producing different alerts than other changes of a collection.
     {
       "uuid": "1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce",
       "name": "Build SBOM",
-      "type": "bom",
+      "type": "BOM",
       "formats": [
         {
-          "mime_type": "application/vnd.cyclonedx+xml",
+          "mimeType": "application/vnd.cyclonedx+xml",
           "description": "CycloneDX SBOM (XML)",
           "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml",
-          "signature_url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc",
+          "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc",
           "checksums": [
             {
               "algType": "MD5",
@@ -207,10 +207,10 @@ producing different alerts than other changes of a collection.
     {
       "uuid": "dfa35519-9734-4259-bba1-3e825cf4be06",
       "name": "Vulnerability Disclosure Report",
-      "type": "vulnerability-assertion",
+      "type": "VULNERABILITIES",
       "formats": [
         {
-          "mime_type": "application/vnd.cyclonedx+xml",
+          "mimeType": "application/vnd.cyclonedx+xml",
           "description": "CycloneDX VDR (XML)",
           "url": "https://logging.apache.org/cyclonedx/vdr.xml",
           "checksums": [

--- a/tea-component/tea-component.md
+++ b/tea-component/tea-component.md
@@ -1,20 +1,18 @@
 # The TEA Component API
 
-The TEA Component object is the object that indicates a product component. The product may
-be constructed with one or multiple Tea Components, each with their own set of
-related artefacts.
+The TEA Component represents a component lineage. A product release may
+be constructed with one or multiple TEA Components, each with their own set of
+releases and related artifacts.
 
-For each TEA COMPONENT there is a TEA COMPONENT INDEX, which is a list of all versions
-for that component.
+Each TEA Component has a list of Component Releases (see `/component/{uuid}/releases`),
+which enumerates all known versions for that component.
 
 The API should be very agnostic as to how a "version" is indicated - semver, vers,
 name, hash or anything else.
 
-## Major and minor versions
+## Versions and TEIs
 
-Each component is for a sub-version or minor version (using semver definitions). A new
-major version counts as a new product with a separate product object (TPO). Each
-product object has one or multiple TEI URNs.
+Each product object has one or multiple TEI URNs.
 
 For the API to be able to present a list of versions in a cronological order,
 a timestamp for a release is required.
@@ -42,7 +40,7 @@ Some examples of Maven artifacts as TEA Components:
   "name": "Apache Log4j API",
   "identifiers": [
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.logging.log4j/log4j-api"
     }
   ]
@@ -55,11 +53,11 @@ Some examples of Maven artifacts as TEA Components:
   "name": "Apache Log4j Core",
   "identifiers": [
     {
-      "idType": "cpe",
+      "idType": "CPE",
       "idValue": "cpe:2.3:a:apache:log4j"
     },
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.logging.log4j/log4j-core"
     }
   ]

--- a/tea-component/tea-release.md
+++ b/tea-component/tea-release.md
@@ -1,0 +1,68 @@
+# TEA Component Release
+
+## Overview
+
+A TEA Component Release represents a specific version of a TEA Component lineage. It is the concrete, versioned entity which has collections of security-related artifacts (SBOM, VDR/VEX, attestations, etc.).
+
+Key attributes:
+- uuid: Unique identifier of the component release
+- component: UUID of the TEA Component this release belongs to
+- version: Human-readable version string
+- createdDate: Timestamp when the release was created in TEA
+- releaseDate: Upstream release timestamp
+- preRelease: Indicates pre-release/beta status
+- identifiers: Array of identifiers (idType: CPE/TEI/PURL; idValue: string)
+
+Collections for a release contain artifacts relevant to that specific release.
+
+## JSON examples
+
+The following examples are reused from the OpenAPI schema (`components/schemas/release.examples`), ensuring exact field names and casing.
+
+```json
+{
+  "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
+  "version": "11.0.6",
+  "createdDate": "2025-04-01T15:43:00Z",
+  "releaseDate": "2025-04-01T15:43:00Z",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6"
+    }
+  ]
+}
+```
+
+```json
+{
+  "uuid": "da89e38e-95e7-44ca-aa7d-f3b6b34c7fab",
+  "version": "10.1.40",
+  "createdDate": "2025-04-01T18:20:00Z",
+  "releaseDate": "2025-04-01T18:20:00Z",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@10.1.40"
+    }
+  ]
+}
+```
+
+```json
+{
+  "uuid": "95f481df-f760-47f4-b2f2-f8b76d858450",
+  "version": "11.0.0-M26",
+  "createdDate": "2024-09-13T17:49:00Z",
+  "preRelease": true,
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
+    }
+  ]
+}
+```
+
+Notes:
+- Use uppercase idType values exactly as defined by the schema enum: CPE, TEI, PURL.

--- a/tea-product/tea-product-release.md
+++ b/tea-product/tea-product-release.md
@@ -1,0 +1,51 @@
+# TEA Product Release
+
+## Overview
+
+A TEA Product Release represents a specific versioned release of a TEA Product. It is the primary resolvable entity via TEI and the entry point for discovery of included components and related collections of security artifacts.
+
+Key attributes:
+- uuid: Unique identifier of the product release
+- product: UUID of the TEA Product this release belongs to
+- version: Human-readable version string of the product release
+- createdDate: Timestamp when the product release was created in TEA
+- releaseDate: Upstream product release timestamp
+- preRelease: Indicates pre-release/beta status
+- identifiers: Array of identifiers (idType: CPE/TEI/PURL; idValue: string)
+- components: Array of component references included in this product release
+  - uuid: UUID of the TEA Component
+  - release: Optional UUID of a specific component release to pin an exact version
+
+Collections for a product release contain artifacts relevant to that product release.
+
+## JSON examples
+
+The following example is reused from the OpenAPI schema (`components/schemas/productRelease.examples`), ensuring exact field names and casing.
+
+```json
+{
+  "uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "version": "2.24.3",
+  "createdDate": "2025-04-01T15:43:00Z",
+  "releaseDate": "2025-04-01T15:43:00Z",
+  "identifiers": [
+    {
+      "idType": "TEI",
+      "idValue": "tei:vendor:product@2.24.3"
+    }
+  ],
+  "components": [
+    {
+      "uuid": "3910e0fd-aff4-48d6-b75f-8bf6b84687f0"
+    },
+    {
+      "uuid": "b844c9bd-55d6-478c-af59-954a932b6ad3",
+      "release": "da89e38e-95e7-44ca-aa7d-f3b6b34c7fab"
+    }
+  ]
+}
+```
+
+Notes:
+- Property `product` exists in the schema and links a product release to its parent product; it may not be present in all examples.
+- Use uppercase idType values exactly as defined by the schema enum: CPE, TEI, PURL.

--- a/tea-product/tea-product.md
+++ b/tea-product/tea-product.md
@@ -1,12 +1,10 @@
 # The TEA product API
 
-After TEA discovery, a user has a URL to the TEA product API where
-the TEI is used to query for data. The TEI marks the product sold,
-which can be a single unit or multiple units in a bundle.
+After TEA discovery, the [Transparency Exchange Identifier (TEI)](/discovery/readme.md) resolves to a specific TEA Product Release, which represents a concrete, versioned offering. A TEA Product is an optional higher-level object that groups multiple Product Releases for a product line or family and can be browsed via `/product/{uuid}/releases`.
 
-- For a single product, the output will be metadata about the
-  product and a TEA COMPONENT object.
-- For a composed product consisting of a bundle, the response
+- A product release may consist of a single component, the output will be metadata about the
+  product and the TEA COMPONENT object.
+- For a composed product release consisting of a bundle of components or component releases, the response
   will be multiple TEA COMPONENT objects.
 
 In addition, all known TEIs for the product will be returned,
@@ -20,9 +18,8 @@ which products and versions are supported for a specific user.
 
 ## Composite products
 
-If a product consists of a set of products, each with a different
-version number and update scheme, a TEA "bundle" will be the starting
-point of discovery. The TEA product will list all included components
+A TEA Product Release will be the starting
+point of discovery. The TEA product release will list all included components
 with the UUID of the TEA component. The reference list may also include
 a UUID of a specific release of a component in the case where a product
 always includes a single release of the component.
@@ -60,36 +57,26 @@ An example of a product consisting of an OSS project and all its Maven artifacts
   "name": "Apache Log4j 2",
   "identifiers": [
     {
-      "idType": "cpe",
+      "idType": "CPE",
       "idValue": "cpe:2.3:a:apache:log4j"
     },
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.logging.log4j/log4j-api"
     },
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.logging.log4j/log4j-core"
     },
     {
-      "idType": "purl",
+      "idType": "PURL",
       "idValue": "pkg:maven/org.apache.logging.log4j/log4j-layout-template-json"
-    }
-  ],
-  "components": [
-    {
-      "uuid": "3910e0fd-aff4-48d6-b75f-8bf6b84687f0",
-      "release": "c1f2f9c4-d86e-4007-b61c-a53dc36f3e72"
-    },
-    {
-      "uuid": "b844c9bd-55d6-478c-af59-954a932b6ad3"
-    },
-    {
-      "uuid": "d6d3f754-d4f4-4672-b096-b994b064ca2d"
     }
   ]
 }
 ```
+
+Releases for this Product can be browsed via the API endpoint `/product/{uuid}/releases`.
 
 ### API usage
 


### PR DESCRIPTION
This PR adds on top of #186  :

1. Concept of Product Release, as discussed on Community Meeting on 2025-08-13 - this implements Product - Product Release and Component - Component Release paradigm, where Product may still be omitted for certain workflows as we also establish global /productReleases endpoint
2. Fixes minor inconsistencies across schema (i.e. unifying casing and uuid reference)