### PR TITLE
Use distributionId instead of distributionType to identifiy disributions

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1030,6 +1030,7 @@ components:
       required:
         - uuid
         - type
+        - formats
     artifact-type:
       type: string
       description: Specifies the type of external reference.


### PR DESCRIPTION
This PR resolves #198 for the 1.0 release. It removes the distributionType string field as it is not clearly enumerated. Instead it introduces the distributionId UUID field that allows to map TEA Artifacts to specific distributions.