### PR TITLE
feat: discovery by PURL as an alternative to TEI

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -763,20 +763,20 @@ paths:
 
         Discovery by TEI resolves the product across TEA servers, using the domain carried
         by the TEI. Discovery by PURL resolves the product within the inventory of the TEA
-        server that receives the request; a PURL carries no domain.
+        server that receives the request.
       operationId: discoveryByTei
       parameters:
         - name: tei
           in: query
           required: false
-          description: Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987. Mutually exclusive with `purl`.
+          description: Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987 or the PURL under purl parameter.
           schema:
             type: string
             example: urn%3Atei%3Auuid%3Aproducts.example.com%3Ad4d9f54a-abcf-11ee-ac79-1a52914d44b
         - name: purl
           in: query
           required: false
-          description: Package URL (PURL) of the product being discovered, resolved within this TEA server's inventory. Provide the PURL as a URL-encoded string per RFC 3986. Mutually exclusive with `tei`.
+          description: Package URL (PURL) of the product being discovered, resolved within this TEA server's inventory. Provide the PURL as a URL-encoded string per RFC 3986 or the TEI under tei parameter.
           schema:
             type: string
             example: pkg%3Amaven%2Forg.apache.logging.log4j%2Flog4j-core%402.24.3

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -754,16 +754,32 @@ paths:
         - TEA Authentication
   /discovery:
     get:
-      description: Discovery endpoint which resolves TEI into product release UUID.
+      description: |
+        Discovery endpoint which resolves an identifier into product release UUID.
+
+        Exactly one of the `tei` and `purl` query parameters shall be provided. A request
+        with neither, or with both, is rejected with `400`. OpenAPI cannot express this
+        constraint on query parameters, so both are declared optional here.
+
+        Discovery by TEI resolves the product across TEA servers, using the domain carried
+        by the TEI. Discovery by PURL resolves the product within the inventory of the TEA
+        server that receives the request; a PURL carries no domain.
       operationId: discoveryByTei
       parameters:
         - name: tei
           in: query
-          required: true
-          description: Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987.
+          required: false
+          description: Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987. Mutually exclusive with `purl`.
           schema:
             type: string
             example: urn%3Atei%3Auuid%3Aproducts.example.com%3Ad4d9f54a-abcf-11ee-ac79-1a52914d44b
+        - name: purl
+          in: query
+          required: false
+          description: Package URL (PURL) of the product being discovered, resolved within this TEA server's inventory. Provide the PURL as a URL-encoded string per RFC 3986. Mutually exclusive with `tei`.
+          schema:
+            type: string
+            example: pkg%3Amaven%2Forg.apache.logging.log4j%2Flog4j-core%402.24.3
       responses:
         '200':
           $ref: "#/components/responses/discovery-response"


### PR DESCRIPTION
/discovery accepts either `tei` or `purl`; exactly one shall be given, a request with neither or both is rejected with 400. OpenAPI cannot express that constraint across query parameters, so `tei` becomes optional and the rule is stated in the descriptions.

Discovery by TEI resolves across TEA servers through the domain the TEI carries; discovery by PURL resolves within the inventory of the server receiving the request, since a PURL carries no domain.

Spec only; documentation unchanged to prevent conflicts with #261 . Validated with openapi-generator v7.12.0 (validate; Go batch generation as CI runs it).