### PR TITLE
Align /token responses with RFC 6749 cache and Basic encoding

### DIFF
--- a/auth/readme.md
+++ b/auth/readme.md
@@ -101,6 +101,7 @@ A successful response is the standard OAuth 2.0 token response (RFC 6749 section
 HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 Cache-Control: no-store
+Pragma: no-cache
 
 {
   "access_token": "2YotnFZFEjr1zCsicMWpAA",

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2149,6 +2149,13 @@ components:
           schema:
             type: string
             example: no-store
+        Pragma:
+          description: |
+            Servers shall set `no-cache` on token responses (RFC 6749 section 5.1), for
+            compatibility with HTTP/1.0 caches.
+          schema:
+            type: string
+            example: no-cache
       content:
         application/json:
           schema:
@@ -2464,7 +2471,11 @@ components:
       description: |
         API key credentials, presented to `/token` only: the API key identifier as the
         user-id and the API key secret as the password (RFC 7617, RFC 6749 section
-        2.3.1). Servers shall not accept API key credentials directly on other TEA
+        2.3.1). Per RFC 6749 section 2.3.1, the identifier and secret are each encoded as
+        `application/x-www-form-urlencoded` before they are joined with a colon and
+        Base64-encoded for the `Authorization` header. Clients and servers shall apply
+        that encoding so credentials containing `:`, `@`, or other reserved characters
+        interoperate. Servers shall not accept API key credentials directly on other TEA
         endpoints; clients shall exchange them for an access token first.
 security:
   - bearerAuth: []


### PR DESCRIPTION
## Summary
- Add `Pragma: no-cache` on successful token responses alongside existing `Cache-Control: no-store`, per RFC 6749 section 5.1
- Document in the `basicAuth` scheme that API key identifier and secret are each `application/x-www-form-urlencoded` encoded before `userid:password` and Base64, per RFC 6749 section 2.3.1
- Align the token success example in `auth/readme.md` with the same `Pragma` header

Closes #271

## Context
RFC 6749 section 5.1 requires both `Cache-Control: no-store` and `Pragma: no-cache` on responses that include tokens. OpenAPI previously only declared `Cache-Control`.

RFC 6749 section 2.3.1 requires form-encoding each credential before building the Basic header. That step matters for secrets containing `:`, `@`, or other reserved characters. `auth/readme.md` already described it; the OpenAPI `basicAuth` description did not.


